### PR TITLE
fix: update ephemeral_account dependency and import style

### DIFF
--- a/contracts/sweep_controller/Cargo.toml
+++ b/contracts/sweep_controller/Cargo.toml
@@ -9,12 +9,12 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 soroban-sdk = "22.0.0"
 bridgelet-shared = { path = "../shared", version = "0.1.0" }
+ephemeral_account = { path = "../ephemeral_account", version = "0.1.0" }
 
 soroban-token-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-ephemeral_account = { path = "../ephemeral_account" }
 
 
 [profile.release]

--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -5,7 +5,7 @@ mod errors;
 mod storage;
 // mod transfers;
 
-use crate::ephemeral_account::Client as EphemeralAccountClient;
+use ephemeral_account::EphemeralAccountContractClient as EphemeralAccountClient;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
 
 use authorization::AuthContext;
@@ -224,12 +224,4 @@ fn emit_destination_updated(env: &Env, old_destination: Option<Address>, new_des
     };
     env.events()
         .publish((soroban_sdk::symbol_short!("dest_upd"),), event);
-}
-
-// Re-export ephemeral_account types for cross-contract calls
-mod ephemeral_account {
-    // Import from the actual ephemeral_account contract
-    soroban_sdk::contractimport!(
-        file = "/home/levai/bridgelet-core/target/wasm32-unknown-unknown/release/ephemeral_account.wasm"
-    );
 }


### PR DESCRIPTION
This pull request updates the `sweep_controller` contract to improve how it interacts with the `ephemeral_account` contract. The main changes are focused on dependency management and simplifying cross-contract calls.

**Dependency and Import Improvements:**

* Added `ephemeral_account` as a regular dependency in `Cargo.toml` and removed it from `dev-dependencies`, ensuring it is always available for the contract, not just during testing.
* Updated the import in `lib.rs` to use `EphemeralAccountContractClient` directly from the `ephemeral_account` crate, simplifying the client usage for cross-contract calls.

**Codebase Cleanup:**

* Removed the manual re-export and contract import block for `ephemeral_account` in `lib.rs`, reducing redundancy and potential for errors. Closes #25 