### PR TITLE
fix: correct sweep signature, document auth stub, and fix creator initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ pub trait EphemeralAccountInterface {
     fn is_expired(env: Env) -> bool;
 }
 ```
-> **⚠️ MVP:**  **authorization is not yet enforced on-chain.
+> **⚠️ MVP:** On-chain authorization is not enforced at the `EphemeralAccount` contract
+> level. Calling `EphemeralAccount::sweep()` directly bypasses all signature verification.
+> Authorization is only enforced when sweeps are routed through `SweepController`.
+> Do not call `EphemeralAccount::sweep()` directly in production.
 
 See [Bridgelet Documentation](https://github.com/bridgelet-org/bridgelet) for full API reference.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pub trait EphemeralAccountInterface {
     fn record_payment(env: Env, amount: i128, asset: Address) -> Result<(), Error>;
     
     // Execute sweep to permanent wallet
-    fn sweep(env: Env, destination: Address) -> Result<(), Error>;
+    fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>) -> Result<(), Error>;
     
     // Check if account is expired
     fn is_expired(env: Env) -> bool;

--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -357,9 +357,12 @@ impl EphemeralAccountContract {
         _destination: &Address,
         _signature: &BytesN<64>,
     ) -> Result<(), Error> {
-        // TODO: Implement proper signature verification
-        // For MVP, we rely on off-chain SDK to only call with valid auth
-        // Future: Verify signature against authorized signer
+        // ⚠️ MVP STUB: Signature verification is NOT enforced on-chain in this contract.
+        // Calling EphemeralAccount::sweep() directly bypasses all authorization checks.
+        // Authorization is only enforced when going through SweepController, which
+        // performs Ed25519 signature verification via authorization.rs.
+        // TODO: Implement on-chain signature verification against an authorized signer
+        // before production use.
         Ok(())
     }
 

--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -30,17 +30,16 @@ impl SweepController {
         env: Env,
         authorized_signer: BytesN<32>,
         authorized_destination: Option<Address>,
+        creator: Address,
     ) -> Result<(), Error> {
         // Check if already initialized
         if storage::get_authorized_signer(&env).is_some() {
             return Err(Error::AuthorizationFailed);
         }
 
-        // Store the creator address
-        // In Soroban SDK 22.0.0, we need to pass creator as a parameter
-        // For now, we'll use the contract address as a placeholder
-        // TODO: Update to accept creator as parameter if needed
-        let creator = env.current_contract_address();
+    
+       // Verify and store the creator address
+        creator.require_auth();
         storage::set_creator(&env, &creator);
 
         // Store the authorized signer public key


### PR DESCRIPTION
closes #39, 
closes #40, 
closes #41.

Changes:
README.md -- updated EphemeralAccountInterface::sweep() signature to include the missing auth_signature: BytesN<64> parameter (#39)
README.md -- replaced the vague MVP warning with a specific callout that EphemeralAccount::sweep() bypasses all authorization checks and that sweeps must be routed through SweepController (#40)
ephemeral_account/src/lib.rs -- replaced the silent TODO comment in verify_sweep_authorization with a clearly visible stub warning explaining the authorization gap and the intended fix (#40)
sweep_controller/src/lib.rs -- added creator: Address as an explicit parameter to initialize, replaced env.current_contract_address() with the passed-in value, and added creator.require_auth() so the caller is verified before storage (#41)