### PR TITLE
fix: enable transfers, testutils feature gate, AccountStatus ordering, scaffold native_transfer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "contracts/sweep_controller",
     "contracts/shared",
     "contracts/reserve_contract",
+    "contracts/native_transfer",
 ]

--- a/contracts/ephemeral_account/Cargo.toml
+++ b/contracts/ephemeral_account/Cargo.toml
@@ -13,6 +13,7 @@ bridgelet-shared = { path = "../shared", version = "0.1.0" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+bridgelet-shared = { path = "../shared", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/native_transfer/Cargo.toml
+++ b/contracts/native_transfer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "native-transfer"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+bridgelet-shared = { path = "../shared" }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+bridgelet-shared = { path = "../shared", features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/native_transfer/src/errors.rs
+++ b/contracts/native_transfer/src/errors.rs
@@ -1,0 +1,8 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    InvalidAmount = 1,
+    TransferFailed = 2,
+}

--- a/contracts/native_transfer/src/events.rs
+++ b/contracts/native_transfer/src/events.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contracttype, symbol_short, Address, Env};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NativeTransferExecuted {
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+}
+
+pub fn emit_native_transfer_executed(env: &Env, from: Address, to: Address, amount: i128) {
+    let event = NativeTransferExecuted { from, to, amount };
+    env.events().publish((symbol_short!("native_tx"),), event);
+}

--- a/contracts/native_transfer/src/lib.rs
+++ b/contracts/native_transfer/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+
+mod errors;
+mod events;
+
+use soroban_sdk::{contract, contractimpl, Env};
+
+pub use errors::Error;
+pub use events::NativeTransferExecuted;
+
+#[contract]
+pub struct NativeTransferContract;
+
+#[contractimpl]
+impl NativeTransferContract {
+    // Implementation coming in a future issue
+}

--- a/contracts/reserve_contract/Cargo.toml
+++ b/contracts/reserve_contract/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+bridgelet-shared = { path = "../shared", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/shared/Cargo.toml
+++ b/contracts/shared/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2021"
 [dependencies]
 soroban-sdk = "22.0.0"
 
+[features]
+testutils = ["soroban-sdk/testutils"]
+
 [lib]
 crate-type = ["rlib"]

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -10,7 +10,7 @@ pub struct Payment {
 }
 // The current status of an ephemeral account.
 #[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Copy)]
 #[repr(u32)]
 pub enum AccountStatus {
     Active = 0,

--- a/contracts/sweep_controller/Cargo.toml
+++ b/contracts/sweep_controller/Cargo.toml
@@ -15,6 +15,7 @@ soroban-token-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+bridgelet-shared = { path = "../shared", features = ["testutils"] }
 
 
 [profile.release]

--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -3,7 +3,7 @@
 mod authorization;
 mod errors;
 mod storage;
-// mod transfers;
+mod transfers;
 
 use ephemeral_account::EphemeralAccountContractClient as EphemeralAccountClient;
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
@@ -115,15 +115,16 @@ impl SweepController {
             return Err(Error::AccountNotReady);
         }
 
-        // Execute the actual token transfer
-        // Note: In production, the ephemeral account would need to authorize this transfer
-        // let transfer_ctx = TransferContext::new(
-        //     info.payment_asset,
-        //     ephemeral_account.clone(),
-        //     destination.clone(),
-        //     amount,
-        // );
-        // transfer_ctx.execute(&env)?;
+        // Execute the actual token transfer for each payment asset
+        for payment in info.payments.iter() {
+            let transfer_ctx = transfers::TransferContext::new(
+                payment.asset.clone(),
+                ephemeral_account.clone(),
+                destination.clone(),
+                payment.amount,
+            );
+            transfer_ctx.execute(&env)?;
+        }
 
         // Emit sweep executed event
         emit_sweep_completed(&env, ephemeral_account, destination, amount);


### PR DESCRIPTION
## Summary

- **#42** — Uncommented `mod transfers` in `sweep_controller/src/lib.rs` and replaced the dead-commented single-transfer block with a loop over `info.payments` using `transfers::TransferContext`, so every payment asset is swept on-chain.
- **#43** — Added `[features] testutils = ["soroban-sdk/testutils"]` to `bridgelet-shared/Cargo.toml` and wired `bridgelet-shared = { features = ["testutils"] }` into `dev-dependencies` for `ephemeral_account`, `sweep_controller`, and `reserve_contract`, fixing test-build failures across the workspace.
- **#44** — Added `PartialOrd, Ord` to `AccountStatus`'s `#[derive(...)]` so contract logic can do ordered comparisons against the well-defined `#[repr(u32)]` state progression (Active → PaymentReceived → Swept → Expired).
- **#48** — Scaffolded `contracts/native_transfer/` with `Cargo.toml`, `src/lib.rs`, `src/errors.rs`, and `src/events.rs` matching the existing contract pattern; registered the crate in the workspace `Cargo.toml`.

## Test plan

- [x] `cargo build` passes for the entire workspace with no errors
- [x] All four changed/new contracts compile cleanly (`bridgelet-shared`, `ephemeral_account`, `sweep_controller`, `reserve_contract`, `native-transfer`)
- [x] Only expected scaffold warnings remain (unused `emit_native_transfer_executed` — no implementation yet)

Closes #42
Closes #43
Closes #44
Closes #48