### PR TITLE
feat: store contract version in instance storage (#113)

### DIFF
--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -17,6 +17,7 @@ pub use events::{
 pub use storage::DataKey;
 
 const BASE_RESERVE_STROOPS: i128 = 1_000_000_000;
+const CONTRACT_VERSION: u32 = 1;
 
 #[contract]
 pub struct EphemeralAccountContract;
@@ -61,6 +62,7 @@ impl EphemeralAccountContract {
         storage::set_status(&env, AccountStatus::Active);
         storage::set_authorized_controller(&env, &authorized_controller);
         storage::init_reserve_tracking(&env, BASE_RESERVE_STROOPS);
+        storage::set_contract_version(&env, CONTRACT_VERSION);
 
         // Emit event
         events::emit_account_created(&env, creator, expiry_ledger);
@@ -196,6 +198,11 @@ impl EphemeralAccountContract {
         let current_ledger = env.ledger().sequence();
 
         current_ledger >= expiry_ledger
+    }
+
+    /// Get the contract version stored at initialization
+    pub fn version(env: Env) -> u32 {
+        storage::get_contract_version(&env)
     }
 
     /// Get current account status

--- a/contracts/ephemeral_account/src/storage.rs
+++ b/contracts/ephemeral_account/src/storage.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
     ReserveEventCount,
     LastReserveEvent,
     AuthorizedController,
+    ContractVersion,
 }
 
 // Initialization
@@ -204,6 +205,20 @@ pub fn set_last_reserve_event(env: &Env, event: &ReserveReclaimed) {
 
 pub fn get_last_reserve_event(env: &Env) -> Option<ReserveReclaimed> {
     env.storage().instance().get(&DataKey::LastReserveEvent)
+}
+
+// Contract version
+pub fn set_contract_version(env: &Env, version: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ContractVersion, &version);
+}
+
+pub fn get_contract_version(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ContractVersion)
+        .unwrap_or(0)
 }
 
 // Authorized controller

--- a/contracts/ephemeral_account/src/test.rs
+++ b/contracts/ephemeral_account/src/test.rs
@@ -40,6 +40,24 @@ mod test {
     }
 
     #[test]
+    fn test_version_stored_on_initialize() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EphemeralAccountContract, ());
+        let client = EphemeralAccountContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let controller = Address::generate(&env);
+        let expiry_ledger = env.ledger().sequence() + 1000;
+
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+
+        assert_eq!(client.version(), 1);
+    }
+
+    #[test]
     fn test_record_payment() {
         let env = Env::default();
         env.mock_all_auths();

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -70,6 +70,13 @@ Checks if the account has passed its expiry ledger.
 fn is_expired(env: Env) -> bool
 ```
 
+#### `version`
+Returns the contract version stored at initialization. Useful for on-chain migration checks.
+
+```rust
+fn version(env: Env) -> u32
+```
+
 #### `get_status`
 Returns the current status of the account (Active, PaymentReceived, Swept, Expired).
 


### PR DESCRIPTION
Closes #113

---

- Add ContractVersion key to DataKey enum in storage.rs
- Add set_contract_version / get_contract_version helpers
- Store CONTRACT_VERSION = 1 during initialize()
- Expose version() public getter
- Add test_version_stored_on_initialize test
- Document version() in docs/api-reference.md