### PR TITLE
feat: enforce minimum payment amount in record_payment() (#111)

### DIFF
--- a/contracts/ephemeral_account/src/errors.rs
+++ b/contracts/ephemeral_account/src/errors.rs
@@ -18,4 +18,5 @@ pub enum Error {
     InvalidStatus = 12,
     DuplicateAsset = 13,
     TooManyPayments = 14,
+    PaymentBelowMinimum = 15,
 }

--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -40,6 +40,7 @@ impl EphemeralAccountContract {
         expiry_ledger: u32,
         recovery_address: Address,
         authorized_controller: Address,
+        min_amount: i128,
     ) -> Result<(), Error> {
         // Check if already initialized
         if storage::is_initialized(&env) {
@@ -55,6 +56,11 @@ impl EphemeralAccountContract {
             return Err(Error::InvalidExpiry);
         }
 
+        // Validate min_amount is non-negative
+        if min_amount < 0 {
+            return Err(Error::InvalidAmount);
+        }
+
         // Store initialization data
         storage::set_initialized(&env, true);
         storage::set_creator(&env, &creator);
@@ -62,6 +68,7 @@ impl EphemeralAccountContract {
         storage::set_recovery_address(&env, &recovery_address);
         storage::set_status(&env, AccountStatus::Active);
         storage::set_authorized_controller(&env, &authorized_controller);
+        storage::set_min_payment_amount(&env, min_amount);
         storage::init_reserve_tracking(&env, BASE_RESERVE_STROOPS);
         storage::set_contract_version(&env, CONTRACT_VERSION);
 
@@ -90,6 +97,12 @@ impl EphemeralAccountContract {
         // Validate amount
         if amount <= 0 {
             return Err(Error::InvalidAmount);
+        }
+
+        // Check minimum payment amount
+        let min_amount = storage::get_min_payment_amount(&env);
+        if amount < min_amount {
+            return Err(Error::PaymentBelowMinimum);
         }
 
         // Check for duplicate asset

--- a/contracts/ephemeral_account/src/storage.rs
+++ b/contracts/ephemeral_account/src/storage.rs
@@ -19,6 +19,7 @@ pub enum DataKey {
     LastReserveEvent,
     AuthorizedController,
     ContractVersion,
+    MinPaymentAmount,
 }
 
 // Initialization
@@ -218,6 +219,20 @@ pub fn get_contract_version(env: &Env) -> u32 {
     env.storage()
         .instance()
         .get(&DataKey::ContractVersion)
+        .unwrap_or(0)
+}
+
+// Minimum payment amount
+pub fn set_min_payment_amount(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::MinPaymentAmount, &amount);
+}
+
+pub fn get_min_payment_amount(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinPaymentAmount)
         .unwrap_or(0)
 }
 

--- a/contracts/ephemeral_account/src/test.rs
+++ b/contracts/ephemeral_account/src/test.rs
@@ -29,7 +29,7 @@ mod test {
         let controller = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
 
         assert_eq!(client.get_status(), AccountStatus::Active);
         assert!(!client.is_expired());
@@ -51,7 +51,7 @@ mod test {
         let controller = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
 
         assert_eq!(client.version(), 1);
     }
@@ -70,7 +70,7 @@ mod test {
         let asset = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&100, &asset);
 
         assert_eq!(client.get_status(), AccountStatus::PaymentReceived);
@@ -91,7 +91,7 @@ mod test {
         let asset2 = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
 
         client.record_payment(&100, &asset1);
         let info = client.get_info();
@@ -119,7 +119,7 @@ mod test {
         let destination = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&100, &asset);
 
         let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
@@ -152,7 +152,7 @@ mod test {
         let asset = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&100, &asset);
         client.record_payment(&50, &asset);
     }
@@ -170,7 +170,7 @@ mod test {
         let controller = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
 
         for i in 0..10 {
             let asset = Address::generate(&env);
@@ -195,7 +195,7 @@ mod test {
         let destination = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
 
         let asset1 = Address::generate(&env);
         let asset2 = Address::generate(&env);
@@ -232,7 +232,7 @@ mod test {
         let asset = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&100, &asset);
 
         let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
@@ -268,7 +268,7 @@ mod test {
         let asset = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&100, &asset);
 
         let initial_available = 250_000_000i128;
@@ -327,7 +327,7 @@ mod test {
         let asset2 = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
 
         // Record two payments that would overflow i128 when summed
         client.record_payment(&i128::MAX, &asset1);
@@ -362,7 +362,7 @@ mod test {
         let asset = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&100, &asset);
 
         let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
@@ -397,7 +397,7 @@ mod test {
         let asset = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 10;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&500, &asset);
 
         // Advance ledger past expiry
@@ -429,10 +429,52 @@ mod test {
         let controller = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
 
         // Attempt to expire before expiry ledger — should return NotExpired (#6)
         client.expire();
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #15)")]
+    fn test_payment_below_minimum_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EphemeralAccountContract, ());
+        let client = EphemeralAccountContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let controller = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let expiry_ledger = env.ledger().sequence() + 1000;
+
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &100i128);
+
+        // Payment of 50 is below minimum of 100 -- should panic with PaymentBelowMinimum (#15)
+        client.record_payment(&50, &asset);
+    }
+
+    #[test]
+    fn test_payment_at_minimum_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EphemeralAccountContract, ());
+        let client = EphemeralAccountContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let controller = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let expiry_ledger = env.ledger().sequence() + 1000;
+
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &100i128);
+
+        // Payment exactly at minimum should succeed
+        client.record_payment(&100, &asset);
+        assert_eq!(client.get_status(), AccountStatus::PaymentReceived);
     }
 
     #[test]
@@ -451,7 +493,7 @@ mod test {
         let destination = Address::generate(&env);
         let expiry_ledger = env.ledger().sequence() + 1000;
 
-        client.initialize(&creator, &expiry_ledger, &recovery, &controller);
+        client.initialize(&creator, &expiry_ledger, &recovery, &controller, &1i128);
         client.record_payment(&100, &asset);
 
         let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
@@ -481,6 +523,6 @@ mod test {
 
         // expiry_ledger <= current ledger (50 <= 100) -- should return InvalidExpiry (#5)
         let expired_ledger = 50u32;
-        client.initialize(&creator, &expired_ledger, &recovery, &controller);
+        client.initialize(&creator, &expired_ledger, &recovery, &controller, &1i128);
     }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,6 +23,7 @@ fn initialize(
 | `creator` | `Address` | The account that created this contract. |
 | `expiry_ledger` | `u32` | The ledger sequence number at which the account expires. |
 | `recovery_address` | `Address` | Where funds are sent if the account expires. |
+| `min_amount` | `i128` | Minimum payment amount accepted by this account. Payments below this value are rejected with `PaymentBelowMinimum`. |
 
 #### `record_payment`
 Records an inbound payment. Supports multiple payments of different assets.
@@ -39,6 +40,8 @@ fn record_payment(
 | :--- | :--- | :--- |
 | `amount` | `i128` | The amount of the payment. Must be positive. |
 | `asset` | `Address` | The address of the asset contract (token). |
+
+Returns `Error::PaymentBelowMinimum` if `amount` is less than the `min_amount` set at initialization.
 
 #### `sweep`
 Authorizes a transfer of all assets to the destination and updates the account state to `Swept`.


### PR DESCRIPTION
- Add PaymentBelowMinimum = 15 to Error enum
- Add MinPaymentAmount key to DataKey enum in storage.rs
- Add set_min_payment_amount / get_min_payment_amount helpers
- Add min_amount: i128 param to initialize()
- Reject payments below minimum with Error::PaymentBelowMinimum
- Add test_payment_below_minimum_rejected and test_payment_at_minimum_accepted
- Update initialize() and record_payment() docs in api-reference.md

closes #111 