### PR TITLE
docs: add CHANGELOG, CONTRIBUTING, storage layout, and error catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to Bridgelet Core are documented in this file.
+
+## [Unreleased]
+
+### Added
+- New `CONTRIBUTING.md` with repository setup, testing, and PR guidelines.
+- New `docs/STORAGE_LAYOUT.md` documenting Soroban instance storage keys for `EphemeralAccount` and `SweepController`.
+- New `docs/ERROR_CATALOGUE.md` publishing complete on-chain error codes for both contracts.
+- Updated `docs/architecture.md` and `docs/api-reference.md` to reflect current contract implementations and authorization flow.
+
+### Documentation
+- Added `CHANGELOG.md` entry for future contract and docs updates.
+- Updated `README.md` documentation links for easier onboarding.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to Bridgelet Core
+
+Thank you for contributing to Bridgelet Core. This guide explains how to set up the repository locally, run tests, and submit high-quality pull requests.
+
+## Project Setup
+
+### Requirements
+- Rust toolchain (stable)
+- `wasm32-unknown-unknown` target
+- `cargo` and `rustup`
+- `soroban-cli` version `22.0.0`
+
+### Install Dependencies
+
+```bash
+rustup toolchain install stable
+rustup target add wasm32-unknown-unknown
+cargo install --locked soroban-cli --version 22.0.0
+```
+
+### Initial Setup
+
+```bash
+git clone https://github.com/bridgelet-org/bridgelet-core.git
+cd bridgelet-core
+```
+
+## Repository Structure
+
+- `contracts/ephemeral_account/` – Ephemeral account contract logic
+- `contracts/sweep_controller/` – Sweep controller contract logic
+- `contracts/shared/` – Shared contract types
+- `contracts/reserve_contract/` – Reserve management contract
+- `docs/` – Architecture, API, security, testing, and storage docs
+
+## Running Tests
+
+### Unit Tests
+
+Run all unit tests for the EphemeralAccount contract:
+
+```bash
+cd contracts/ephemeral_account
+cargo test
+```
+
+Run all unit tests for the SweepController contract:
+
+```bash
+cd contracts/sweep_controller
+cargo test
+```
+
+### Integration Tests
+
+Integration tests for the sweep controller are located under `contracts/sweep_controller/tests/integration.rs`.
+
+```bash
+cd contracts/sweep_controller
+cargo test --test integration
+```
+
+### All Workspace Tests
+
+To run tests across the entire workspace:
+
+```bash
+cargo test
+```
+
+### Formatting and Linting
+
+Apply formatting:
+
+```bash
+cargo fmt
+```
+
+Check formatting:
+
+```bash
+cargo fmt -- --check
+```
+
+Run lints:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+## Branching and PRs
+
+### Branch Naming
+Use feature branches with clear names, for example:
+
+- `docs/issue-94-97-add-docs`
+- `fix/sweep-controller-auth`
+- `feat/storage-layout-docs`
+
+### Pull Request Guidelines
+- Open one PR per logical change set.
+- Reference the related GitHub issues in the PR description.
+- Include a short summary of what changed and why.
+- Add testing steps and note any workarounds.
+
+### Commit Messages
+- Keep commit messages clear and focused.
+- Use present tense, e.g. `Add error catalogue docs`.
+- Reference issue numbers when appropriate.
+
+## Documentation
+
+Documentation should be updated whenever:
+- contracts change behavior
+- new storage keys are added
+- new error codes are introduced
+- test or deployment workflows change
+
+## Issue and Review Workflow
+
+- Assign yourself to issues you are working on.
+- Keep the branch focused on the assigned issue(s).
+- Rebase or merge from `main` before final review.
+- Ensure CI passes before requesting review.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ See [Security Audit Report](./docs/security-audit.md) (coming soon)
 - [API Reference](./docs/api-reference.md)
 - [Security Model](./docs/security.md)
 - [Testing Guide](./docs/testing.md)
+- [Storage Layout](./docs/STORAGE_LAYOUT.md)
+- [Error Catalogue](./docs/ERROR_CATALOGUE.md)
+- [Contributing Guide](./CONTRIBUTING.md)
+- [Changelog](./CHANGELOG.md)
 
 ## License
 

--- a/docs/ERROR_CATALOGUE.md
+++ b/docs/ERROR_CATALOGUE.md
@@ -1,0 +1,51 @@
+# Error Catalogue
+
+This document lists every contract error variant for the `EphemeralAccount` and `SweepController` contracts.
+
+## EphemeralAccount Contract Errors
+
+The `EphemeralAccount` contract defines the following error codes in `contracts/ephemeral_account/src/errors.rs`.
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| 1 | `AlreadyInitialized` | The contract was already initialized. |
+| 2 | `NotInitialized` | The contract has not been initialized yet. |
+| 3 | `PaymentAlreadyReceived` | Deprecated alias; payments are now tracked by asset. |
+| 4 | `InvalidAmount` | The payment amount is zero or negative. |
+| 5 | `InvalidExpiry` | The expiry ledger is not in the future. |
+| 6 | `NotExpired` | Attempted to expire before the expiry ledger. |
+| 7 | `AlreadySwept` | A sweep has already been executed. |
+| 8 | `Unauthorized` | Authorization failed during sweep validation. |
+| 9 | `InvalidSignature` | The provided signature is malformed or invalid. |
+| 10 | `NoPaymentReceived` | No payment has been recorded yet. |
+| 11 | `AccountExpired` | The account has already expired and cannot be swept. |
+| 12 | `InvalidStatus` | The requested operation is invalid for the current account status. |
+| 13 | `DuplicateAsset` | A payment for this asset already exists. |
+| 14 | `TooManyPayments` | The maximum supported payment count (10) has been exceeded. |
+
+### Notes
+- `DuplicateAsset` replaces the earlier single-payment error handling model and supports multiple assets per account.
+- `TooManyPayments` protects against gas and storage exhaustion by limiting the number of distinct assets.
+
+## SweepController Contract Errors
+
+The `SweepController` contract defines the following error codes in `contracts/sweep_controller/src/errors.rs`.
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| 1 | `InvalidAccount` | The provided account is not in a valid state for sweeping. |
+| 2 | `TransferFailed` | The token transfer step failed during sweep execution. |
+| 3 | `AuthorizationFailed` | Signature verification or initialization failed. |
+| 4 | `InsufficientBalance` | The source account does not have enough balance. |
+| 5 | `AccountNotReady` | The account is not ready for sweep (no payment or invalid state). |
+| 6 | `AccountExpired` | The account has already expired. |
+| 7 | `AccountAlreadySwept` | The sweep operation has already been completed. |
+| 8 | `InvalidSignature` | The signature format is invalid. |
+| 9 | `SignatureVerificationFailed` | Ed25519 signature verification failed. |
+| 10 | `AuthorizedSignerNotSet` | The controller has no authorized signer configured. |
+| 11 | `InvalidNonce` | The sweep nonce is invalid or replayed. |
+| 13 | `UnauthorizedDestination` | The destination does not match the locked authorized destination. |
+
+### Notes
+- `AuthorizedSignerNotSet` indicates the contract was never initialized with an authorized signer.
+- `UnauthorizedDestination` only applies when a destination lock is set during initialization.

--- a/docs/STORAGE_LAYOUT.md
+++ b/docs/STORAGE_LAYOUT.md
@@ -1,0 +1,46 @@
+# Storage Layout
+
+This document details the Soroban instance storage layout for the `EphemeralAccount` and `SweepController` contracts.
+
+## EphemeralAccount Storage Layout
+
+The `EphemeralAccount` contract stores all state in Soroban instance storage. The current keys are defined in `contracts/ephemeral_account/src/storage.rs`.
+
+| Storage Key | Type | Purpose | Set By | Read By |
+| --- | --- | --- | --- | --- |
+| `Initialized` | `bool` | Tracks whether the contract has been initialized. | `initialize()` | All entry points |
+| `Creator` | `Address` | Creator address of the ephemeral account. | `initialize()` | `get_info()`, audit logic |
+| `ExpiryLedger` | `u32` | Ledger at which the account expires. | `initialize()` | `is_expired()`, `expire()` |
+| `RecoveryAddress` | `Address` | Address to recover funds after expiry. | `initialize()` | `expire()`, `get_info()` |
+| `Payments` | `Map<Address, Payment>` | Recorded payments keyed by asset address. Supports multiple assets. | `record_payment()` | `get_info()`, `sweep()`, `execute_transfers()` |
+| `Status` | `AccountStatus` | Current account lifecycle state. | `initialize()`, `record_payment()`, `sweep()`, `expire()` | `get_status()`, state checks |
+| `SweptTo` | `Address` | Destination address used for the sweep. | `sweep()` | `get_info()` |
+| `BaseReserveRemaining` | `i128` | Remaining base reserve in stroops. | `init_reserve_tracking()`, reclaim logic | Reserve management |
+| `AvailableReserve` | `i128` | Available reserve balance for reclaiming. | `init_reserve_tracking()` | Reserve management |
+| `ReserveReclaimed` | `bool` | Indicates whether reserve reclamation is complete. | `init_reserve_tracking()` | Reserve management |
+| `LastSweepId` | `u64` | Ledger-based sweep identifier. | `sweep()` | Audit and event tracking |
+| `ReserveEventCount` | `u32` | Number of reserve reclaim events recorded. | `init_reserve_tracking()` | Audit and event tracking |
+| `LastReserveEvent` | `ReserveReclaimed` | Details of the last reserve reclaim event. | Reserve reclaim logic | Audit and event tracking |
+| `AuthorizedController` | `Address` | Controller authorized to manage the account. | `initialize()` | Authorization logic |
+| `ContractVersion` | `u32` | Version of the contract at initialization. | `initialize()` | `version()` |
+
+### Notes
+- `Payments` uses a Soroban `Map` keyed by asset address, allowing multiple asset payments while preventing duplicate assets.
+- Base reserve fields are initialized during account creation and updated during sweep/expiry operations.
+- `Status` is the primary state machine driver for the account lifecycle.
+
+## SweepController Storage Layout
+
+The `SweepController` contract stores its authorization state in instance storage.
+
+| Storage Key | Type | Purpose | Set By | Read By |
+| --- | --- | --- | --- | --- |
+| `AuthorizedSigner` | `BytesN<32>` | Ed25519 public key used for sweep authorization. | `initialize()` | `execute_sweep()`, `AuthContext::verify()` |
+| `SweepNonce` | `u64` | Monotonic nonce to prevent replay attacks. | `init_sweep_nonce()`, `increment_nonce()` | `authorization::verify_sweep_auth()`, `execute_sweep()` |
+| `AuthorizedDestination` | `Option<Address>` | Optional destination lock for sweeps. | `initialize()`, `update_authorized_destination()` | `execute_sweep()` |
+| `Creator` | `Address` | Address that initialized the sweep controller. | `initialize()` | `update_authorized_destination()` |
+
+### Notes
+- `SweepNonce` must increase after each successful sweep authorization.
+- `AuthorizedDestination` is optional. When set, all sweep requests must target the locked destination.
+- The controller separates on-chain authorization from the `EphemeralAccount` contract's state logic.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -126,6 +126,8 @@ struct Payment {
 
 ### Error Codes
 
+For the full published error catalogue, see [docs/ERROR_CATALOGUE.md](./ERROR_CATALOGUE.md).
+
 | Code | Name | Description |
 | :--- | :--- | :--- |
 | 1 | `AlreadyInitialized` | Contract already initialized. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,8 @@ This architecture document covers:
 - Integration patterns and off-chain requirements
 - Current limitations and future improvement plans
 
+It also links to companion reference docs for on-chain storage layout and error catalogues.
+
 ---
 
 ## System Architecture


### PR DESCRIPTION
This PR adds documentation to close assigned issues

Closes #94 
Closes #95 
Closes #96 
Closes #97

Changes included:
- Added `CHANGELOG.md`
- Added `CONTRIBUTING.md`
- Added `docs/STORAGE_LAYOUT.md`
- Added `docs/ERROR_CATALOGUE.md`
- Updated `README.md` links
- Updated `docs/api-reference.md` to link the published error catalogue
- Updated `docs/architecture.md` to reference companion docs

These are documentation-only changes and do not modify contract source code.

Note: local Rust tooling was unavailable in this environment, so tests were not executed here. The change is limited to docs and should not affect existing workflows.