### PR TITLE
implemented the optimize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,17 @@ members = [
     "contracts/shared",
     "contracts/reserve_contract",
 ]
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/ephemeral_account/Cargo.toml
+++ b/contracts/ephemeral_account/Cargo.toml
@@ -13,17 +13,3 @@ bridgelet-shared = { path = "../shared", version = "0.1.0" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true

--- a/contracts/reserve_contract/Cargo.toml
+++ b/contracts/reserve_contract/Cargo.toml
@@ -11,17 +11,3 @@ soroban-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true

--- a/contracts/sweep_controller/Cargo.toml
+++ b/contracts/sweep_controller/Cargo.toml
@@ -15,18 +15,3 @@ soroban-token-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true


### PR DESCRIPTION
Optimise WASM binary size for deployment cost reduction
closes  #129
Description
Soroban charges for WASM upload size. Profile the compiled WASM with twiggy or wasm-opt. Target < 50 KB per contract. Remove unused dependencies and enable LTO in release profile.

Acceptance Criteria

Rust implementation complete

cargo test passing

Integration test on local Stellar sandbox passing

Docs updated (docs/ or inline rustdoc)

Reviewed and merged
