### PR TITLE
refactor: share expire/recover state transition + add proptest property tests

### DIFF
--- a/contracts/ephemeral_account/Cargo.toml
+++ b/contracts/ephemeral_account/Cargo.toml
@@ -13,3 +13,4 @@ bridgelet-shared = { path = "../shared", version = "0.1.0" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+proptest = "1"

--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -282,37 +282,10 @@ impl EphemeralAccountContract {
             return Err(Error::NotExpired);
         }
 
-        // Get recovery address
-        let recovery_address = storage::get_recovery_address(&env);
-
-        // Update status
-        storage::set_status(&env, AccountStatus::Expired);
-        storage::set_swept_to(&env, &recovery_address);
-
-        // Get total amount from all payments if any payments were received
-        let total_amount = if storage::has_payment_received(&env) {
-            let payments = storage::get_all_payments(&env);
-            let mut total = 0i128;
-            for (_, payment) in payments.iter() {
-                total = total
-                    .checked_add(payment.amount)
-                    .ok_or(Error::InvalidAmount)?;
-            }
-            total
-        } else {
-            0
-        };
-
-        let sweep_id = env.ledger().sequence() as u64;
-        storage::set_last_sweep_id(&env, sweep_id);
-
-        // Reclaim reserve to recovery destination.
-        let reclaimed_reserve = Self::reclaim_reserve_to(&env, &recovery_address, sweep_id)?;
-
-        // Emit expiration event with reserve amount reclaimed in this call.
-        events::emit_account_expired(&env, recovery_address, total_amount, reclaimed_reserve);
-
-        Ok(())
+        // expire() is intentionally permissionless (see docs/security.md threat
+        // model #3): anyone may trigger cleanup once the account has expired.
+        // The fund-routing state transition itself is shared with recover().
+        Self::finalize_expiry(&env)
     }
 
     /// Reclaim remaining base reserve for a previously swept/expired account.
@@ -434,29 +407,9 @@ impl EphemeralAccountContract {
         }
         caller.require_auth();
 
-        storage::set_status(&env, AccountStatus::Expired);
-        storage::set_swept_to(&env, &recovery_address);
-
-        let total_amount = if storage::has_payment_received(&env) {
-            let payments = storage::get_all_payments(&env);
-            let mut total = 0i128;
-            for (_, payment) in payments.iter() {
-                total = total
-                    .checked_add(payment.amount)
-                    .ok_or(Error::InvalidAmount)?;
-            }
-            total
-        } else {
-            0
-        };
-
-        let sweep_id = env.ledger().sequence() as u64;
-        storage::set_last_sweep_id(&env, sweep_id);
-
-        let reclaimed_reserve = Self::reclaim_reserve_to(&env, &recovery_address, sweep_id)?;
-        events::emit_account_expired(&env, recovery_address, total_amount, reclaimed_reserve);
-
-        Ok(())
+        // Same fund-routing state transition as expire(); the only difference
+        // between the two entry points is recover()'s narrower access check.
+        Self::finalize_expiry(&env)
     }
 
     /// Upgrade the contract WASM. Restricted to the admin set at deploy time.
@@ -511,6 +464,40 @@ impl EphemeralAccountContract {
     }
 
     // Private helper functions
+
+    /// Shared fund-routing state transition used by both `expire` and
+    /// `recover`. Marks the account `Expired`, routes funds to the recovery
+    /// address, reclaims the base reserve, and emits the expiration event.
+    ///
+    /// Callers are responsible for verifying initialization, status, and
+    /// expiry — and for enforcing any access control — before invoking it.
+    fn finalize_expiry(env: &Env) -> Result<(), Error> {
+        let recovery_address = storage::get_recovery_address(env);
+
+        storage::set_status(env, AccountStatus::Expired);
+        storage::set_swept_to(env, &recovery_address);
+
+        let total_amount = if storage::has_payment_received(env) {
+            let payments = storage::get_all_payments(env);
+            let mut total = 0i128;
+            for (_, payment) in payments.iter() {
+                total = total
+                    .checked_add(payment.amount)
+                    .ok_or(Error::InvalidAmount)?;
+            }
+            total
+        } else {
+            0
+        };
+
+        let sweep_id = env.ledger().sequence() as u64;
+        storage::set_last_sweep_id(env, sweep_id);
+
+        let reclaimed_reserve = Self::reclaim_reserve_to(env, &recovery_address, sweep_id)?;
+        events::emit_account_expired(env, recovery_address, total_amount, reclaimed_reserve);
+
+        Ok(())
+    }
 
     fn verify_sweep_authorization(
         env: &Env,

--- a/contracts/ephemeral_account/tests/property_tests.rs
+++ b/contracts/ephemeral_account/tests/property_tests.rs
@@ -20,7 +20,7 @@ use soroban_sdk::{
 };
 
 proptest! {
-    #![proptest_config(ProptestConfig { cases: 48, ..ProptestConfig::default() })]
+    #![proptest_config(ProptestConfig { cases: 48, failure_persistence: None, ..ProptestConfig::default() })]
 
     // Invariant 1: the tracked reserve never goes negative after a sweep, for
     // any set of valid positive payment amounts (1..=10 assets).
@@ -65,7 +65,8 @@ proptest! {
     // rejected with Error::AccountExpired.
     #[test]
     fn expired_account_always_rejects_sweep(
-        advance in 0u32..=10_000u32,
+        expiry_offset in 1u32..=50u32,
+        past in 0u32..=50u32,
         amount in 1i128..=1_000_000_000_000i128,
     ) {
         let env = Env::default();
@@ -79,7 +80,9 @@ proptest! {
         let controller = Address::generate(&env);
         let asset = Address::generate(&env);
         let destination = Address::generate(&env);
-        let expiry_ledger = env.ledger().sequence() + 1;
+
+        let start = env.ledger().sequence();
+        let expiry_ledger = start + expiry_offset;
 
         client.initialize(
             &creator,
@@ -90,8 +93,9 @@ proptest! {
         );
         client.record_payment(&amount, &asset);
 
-        // Move the ledger to at-or-after the expiry point.
-        env.ledger().set_sequence_number(expiry_ledger + advance);
+        // Move to at-or-after expiry. The advance is kept small so the contract
+        // instance stays within its TTL and is not archived by the test host.
+        env.ledger().set_sequence_number(expiry_ledger + past);
 
         let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
         let result = client.try_sweep(&destination, &auth_sig);

--- a/contracts/ephemeral_account/tests/property_tests.rs
+++ b/contracts/ephemeral_account/tests/property_tests.rs
@@ -1,0 +1,134 @@
+//! Issue #167 / #58: Property-based tests with `proptest`.
+//!
+//! These tests generate randomized valid/invalid inputs and assert invariants
+//! that must hold for every generated case:
+//!
+//! 1. `amount_never_negative_after_sweep` — after a successful sweep the tracked
+//!    reserve amounts are never negative, regardless of the payment amounts.
+//! 2. `expired_account_always_rejects_sweep` — once past the expiry ledger a
+//!    sweep is always rejected with `Error::AccountExpired`.
+//! 3. `double_initialize_always_fails` — a second `initialize` call always
+//!    fails with `Error::AlreadyInitialized`.
+
+use ephemeral_account::{
+    AccountStatus, EphemeralAccountContract, EphemeralAccountContractClient, Error,
+};
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, BytesN, Env,
+};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 48, ..ProptestConfig::default() })]
+
+    // Invariant 1: the tracked reserve never goes negative after a sweep, for
+    // any set of valid positive payment amounts (1..=10 assets).
+    #[test]
+    fn amount_never_negative_after_sweep(
+        amounts in prop::collection::vec(1i128..=1_000_000_000_000i128, 1..=10)
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EphemeralAccountContract, ());
+        let client = EphemeralAccountContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let controller = Address::generate(&env);
+        let destination = Address::generate(&env);
+        let expiry_ledger = env.ledger().sequence() + 1000;
+
+        client.initialize(
+            &creator,
+            &expiry_ledger,
+            &recovery,
+            &controller,
+            &Address::generate(&env),
+        );
+
+        for amount in amounts.iter() {
+            let asset = Address::generate(&env);
+            client.record_payment(amount, &asset);
+        }
+
+        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
+        client.sweep(&destination, &auth_sig);
+
+        prop_assert_eq!(client.get_status(), AccountStatus::Swept);
+        prop_assert!(client.get_reserve_remaining() >= 0);
+        prop_assert!(client.get_reserve_available() >= 0);
+    }
+
+    // Invariant 2: any sweep attempted at or after the expiry ledger is
+    // rejected with Error::AccountExpired.
+    #[test]
+    fn expired_account_always_rejects_sweep(
+        advance in 0u32..=10_000u32,
+        amount in 1i128..=1_000_000_000_000i128,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EphemeralAccountContract, ());
+        let client = EphemeralAccountContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let controller = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let destination = Address::generate(&env);
+        let expiry_ledger = env.ledger().sequence() + 1;
+
+        client.initialize(
+            &creator,
+            &expiry_ledger,
+            &recovery,
+            &controller,
+            &Address::generate(&env),
+        );
+        client.record_payment(&amount, &asset);
+
+        // Move the ledger to at-or-after the expiry point.
+        env.ledger().set_sequence_number(expiry_ledger + advance);
+
+        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
+        let result = client.try_sweep(&destination, &auth_sig);
+
+        prop_assert!(matches!(result, Err(Ok(Error::AccountExpired))));
+    }
+
+    // Invariant 3: initializing an already-initialized account always fails
+    // with Error::AlreadyInitialized, for any valid future expiry.
+    #[test]
+    fn double_initialize_always_fails(offset in 1u32..=1_000_000u32) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(EphemeralAccountContract, ());
+        let client = EphemeralAccountContractClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let expiry_ledger = env.ledger().sequence() + offset;
+
+        client.initialize(
+            &creator,
+            &expiry_ledger,
+            &recovery,
+            &Address::generate(&env),
+            &Address::generate(&env),
+        );
+
+        let result = client.try_initialize(
+            &creator,
+            &(expiry_ledger + 1),
+            &recovery,
+            &Address::generate(&env),
+            &Address::generate(&env),
+        );
+
+        prop_assert!(matches!(result, Err(Ok(Error::AlreadyInitialized))));
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses two issues in `contracts/ephemeral_account`.

### #223 — `expire()` / `recover()` duplicated state transition
`expire()` and `recover()` contained ~90% duplicated fund-routing logic (status → `Expired`, funds routed to the recovery address, reserve reclaimed, expiration event emitted), which is a real maintenance/audit-surface risk: a future fix to one could easily be missed in the other.

This collapses that shared logic into a single private `finalize_expiry()` helper that both functions call:
- `expire()` stays intentionally permissionless (per `docs/security.md` threat model #3 — anyone can trigger cleanup once expired).
- `recover()` keeps its narrower access check (caller must be `creator` or `recovery_address`, plus `require_auth()`).

Behavior is unchanged; the state-transition logic now lives in exactly one place. Existing tests for both paths continue to cover it.

### #167 — Property-based tests with `proptest`
Adds `proptest` as a dev-dependency and a new integration test suite (`tests/property_tests.rs`) covering the three properties from the issue:
1. **Amount never goes negative after sweep** — for any set of valid positive payment amounts, the tracked reserve is never negative after a sweep.
2. **Expired account always rejects sweep** — any sweep at or after the expiry ledger is rejected with `Error::AccountExpired`.
3. **Double-init always fails** — a second `initialize` always returns `Error::AlreadyInitialized`.

Closes #223
Closes #167