### PR TITLE
feat: centralise soroban-sdk pin and publish interface traits to shared

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ members = [
     "contracts/account_factory",
 ]
 
+# Issue #41: centralise the soroban-sdk version pin for every workspace member.
+[workspace.dependencies]
+soroban-sdk = "22.0.0"
+
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ There is no `scripts/test-local.sh` in this repo - earlier README drafts referen
 
 ## Contract Interfaces
 
+These interfaces are published as real Rust traits in
+[`contracts/shared/src/interfaces.rs`](contracts/shared/src/interfaces.rs)
+(`EphemeralAccountInterface`, `SweepControllerInterface`). Each contract
+implements the matching trait, so the interface stays in sync with the
+implementation at compile time. The error type is an associated type, letting
+each contract keep its own error enum.
+
 ### EphemeralAccount (actual signatures)
 ```rust
 pub trait EphemeralAccountInterface {

--- a/contracts/account_factory/Cargo.toml
+++ b/contracts/account_factory/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "22.0.0"
+soroban-sdk = { workspace = true }
 bridgelet-shared = { path = "../shared", version = "0.1.0" }
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 ephemeral_account = { path = "../ephemeral_account", version = "0.1.0" }

--- a/contracts/ephemeral_account/Cargo.toml
+++ b/contracts/ephemeral_account/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "22.0.0"
+soroban-sdk = { workspace = true }
 bridgelet-shared = { path = "../shared", version = "0.1.0" }
 
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -8,7 +8,7 @@ mod test;
 
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
 
-pub use bridgelet_shared::{AccountInfo, AccountStatus, Payment};
+pub use bridgelet_shared::{AccountInfo, AccountStatus, EphemeralAccountInterface, Payment};
 pub use errors::Error;
 pub use events::{
     AccountCreated, AccountExpired, MultiPaymentReceived, PaymentReceived, ReserveReclaimed,
@@ -588,5 +588,45 @@ impl EphemeralAccountContract {
         storage::set_reserve_event_count(env, next_count);
 
         Ok(())
+    }
+}
+
+/// Issue #43: conform to the shared interface for type-safe SDK integration.
+/// Each method delegates to the inherent contract implementation above.
+impl EphemeralAccountInterface for EphemeralAccountContract {
+    type Error = Error;
+
+    fn initialize(
+        env: Env,
+        creator: Address,
+        expiry_ledger: u32,
+        recovery_address: Address,
+        authorized_controller: Address,
+        admin: Address,
+    ) -> Result<(), Error> {
+        Self::initialize(
+            env,
+            creator,
+            expiry_ledger,
+            recovery_address,
+            authorized_controller,
+            admin,
+        )
+    }
+
+    fn record_payment(env: Env, amount: i128, asset: Address) -> Result<(), Error> {
+        Self::record_payment(env, amount, asset)
+    }
+
+    fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>) -> Result<(), Error> {
+        Self::sweep(env, destination, auth_signature)
+    }
+
+    fn sweep_claim(env: Env, destination: Address) -> Result<(), Error> {
+        Self::sweep_claim(env, destination)
+    }
+
+    fn is_expired(env: Env) -> bool {
+        Self::is_expired(env)
     }
 }

--- a/contracts/reserve_contract/Cargo.toml
+++ b/contracts/reserve_contract/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "22.0.0"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/shared/Cargo.toml
+++ b/contracts/shared/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-soroban-sdk = "22.0.0"
+soroban-sdk = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/contracts/shared/src/interfaces.rs
+++ b/contracts/shared/src/interfaces.rs
@@ -1,0 +1,63 @@
+//! Issue #43: shared contract interface traits.
+//!
+//! These traits move the interface definitions that previously lived only in
+//! the README into real, type-checked Rust. Each contract implements the trait
+//! matching the methods it already exposes, so the interface stays in sync with
+//! the implementation at compile time. The error type is left as an associated
+//! type so each contract can keep its own `contracterror` enum.
+
+use soroban_sdk::{Address, BytesN, Env};
+
+/// Interface exposed by the ephemeral account contract.
+pub trait EphemeralAccountInterface {
+    /// Contract-specific error type.
+    type Error;
+
+    /// Initialize the ephemeral account with its restrictions.
+    fn initialize(
+        env: Env,
+        creator: Address,
+        expiry_ledger: u32,
+        recovery_address: Address,
+        authorized_controller: Address,
+        admin: Address,
+    ) -> Result<(), Self::Error>;
+
+    /// Record an inbound payment to this account.
+    fn record_payment(env: Env, amount: i128, asset: Address) -> Result<(), Self::Error>;
+
+    /// Sweep funds to `destination`. `auth_signature` is accepted but not
+    /// cryptographically verified by this contract.
+    fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>) -> Result<(), Self::Error>;
+
+    /// Gas-free sweep path used by the sweep controller's claim flow.
+    fn sweep_claim(env: Env, destination: Address) -> Result<(), Self::Error>;
+
+    /// Whether the account has passed its expiry ledger.
+    fn is_expired(env: Env) -> bool;
+}
+
+/// Interface exposed by the sweep controller contract.
+pub trait SweepControllerInterface {
+    /// Contract-specific error type.
+    type Error;
+
+    /// Initialize the controller with its authorized signer.
+    fn initialize(
+        env: Env,
+        creator: Address,
+        authorized_signer: BytesN<32>,
+        authorized_destination: Option<Address>,
+    ) -> Result<(), Self::Error>;
+
+    /// Execute a sweep from an ephemeral account to `destination`.
+    fn execute_sweep(
+        env: Env,
+        ephemeral_account: Address,
+        destination: Address,
+        auth_signature: BytesN<64>,
+    ) -> Result<(), Self::Error>;
+
+    /// Claim funds to `recipient` using Soroban auth entries.
+    fn claim(env: Env, recipient: Address, ephemeral_account: Address) -> Result<(), Self::Error>;
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+mod interfaces;
 mod types;
 
+pub use interfaces::{EphemeralAccountInterface, SweepControllerInterface};
 pub use types::{AccountInfo, AccountInitRequest, AccountInitResult, AccountStatus, Payment};

--- a/contracts/sweep_controller/Cargo.toml
+++ b/contracts/sweep_controller/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "22.0.0"
+soroban-sdk = { workspace = true }
 bridgelet-shared = { path = "../shared", version = "0.1.0" }
 
 soroban-token-sdk = "22.0.0"
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 ephemeral_account = { path = "../ephemeral_account", version = "0.1.0" }

--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -18,7 +18,7 @@ use soroban_sdk::{
 };
 
 use authorization::AuthContext;
-use bridgelet_shared::{AccountStatus, Payment};
+use bridgelet_shared::{AccountStatus, Payment, SweepControllerInterface};
 pub use errors::Error;
 
 #[contract]
@@ -289,6 +289,34 @@ impl SweepController {
         emit_destination_updated(&env, old_destination, new_destination);
 
         Ok(())
+    }
+}
+
+/// Issue #43: conform to the shared interface for type-safe SDK integration.
+/// Each method delegates to the inherent contract implementation above.
+impl SweepControllerInterface for SweepController {
+    type Error = Error;
+
+    fn initialize(
+        env: Env,
+        creator: Address,
+        authorized_signer: BytesN<32>,
+        authorized_destination: Option<Address>,
+    ) -> Result<(), Error> {
+        Self::initialize(env, creator, authorized_signer, authorized_destination)
+    }
+
+    fn execute_sweep(
+        env: Env,
+        ephemeral_account: Address,
+        destination: Address,
+        auth_signature: BytesN<64>,
+    ) -> Result<(), Error> {
+        Self::execute_sweep(env, ephemeral_account, destination, auth_signature)
+    }
+
+    fn claim(env: Env, recipient: Address, ephemeral_account: Address) -> Result<(), Error> {
+        Self::claim(env, recipient, ephemeral_account)
     }
 }
 


### PR DESCRIPTION
Two related shared/build issues, in one branch.

closes #142
closes #144

## #142 — Centralise the `soroban-sdk` version pin
The workspace already existed but each member pinned `soroban-sdk = "22.0.0"` independently.

- Add `[workspace.dependencies]` to the root `Cargo.toml` with `soroban-sdk = "22.0.0"`.
- Switch every member (`shared`, `ephemeral_account`, `sweep_controller`, `reserve_contract`, `account_factory`) to `soroban-sdk = { workspace = true }`, and the `testutils` dev-dependency to `{ workspace = true, features = ["testutils"] }`.

The version is unchanged (22.0.0), so the lockfile and resolution are unaffected — this only moves the single source of truth to the workspace root.

## #144 — Publish contract interface traits to `shared`
The `EphemeralAccountInterface` / `SweepControllerInterface` definitions lived only in the README.

- Add `contracts/shared/src/interfaces.rs` with both traits as real Rust. The error is an **associated type** (`type Error;`) so each contract keeps its own `contracterror` enum while still conforming to a shared interface.
- `EphemeralAccountContract` implements `EphemeralAccountInterface`; `SweepController` implements `SweepControllerInterface`. Each trait method delegates to the contract's existing inherent method, giving compile-time, type-safe interface conformance without changing the exported contract ABI.
- README updated to point at the shared traits.

## Notes / CI
The changes were made to match the crates' existing rustfmt-clean formatting (signatures copied verbatim from the inherent methods, delegation bodies kept within the 100-column limit) and the inherent implementations are untouched, so `cargo test` behaviour is unchanged. I was not able to run the toolchain (`cargo fmt`/`clippy`/`stellar contract build`) in my environment, so if CI surfaces any nit I'll fix it promptly.
