### PR TITLE
docs(audit): close Mai-Fura runbook issues #283, #293

### DIFF
--- a/bridgelet-audit/runbooks/reserve-contract-admin-key-rotation.md
+++ b/bridgelet-audit/runbooks/reserve-contract-admin-key-rotation.md
@@ -1,0 +1,195 @@
+# Runbook: Rotating `ReserveContract`'s Admin Key
+
+**Audience:** operators / SREs / on-call engineers responsible for the Bridgelet Core deployment.
+
+**Scope:** rotating the admin address stored inside a deployed `ReserveContract` instance (`contracts/reserve_contract/src/lib.rs`).
+
+**When to use this runbook:** the admin secret key has been (or is suspected of being) compromised; an operator is leaving the team; periodic scheduled rotation; any time the current admin address should no longer hold write authority over `set_base_reserve`.
+
+---
+
+## Important: there is no in-place `transfer_admin`
+
+`ReserveContract` (see [`contracts/reserve_contract/src/lib.rs`](../../contracts/reserve_contract/src/lib.rs)) currently exposes exactly one admin-writing function: `initialize(env, admin)`. The `DataKey::Admin` slot is written once at `initialize()` and never mutated, because the contract has **no** `transfer_admin` (or equivalent) function today. Verifying this against the source:
+
+```rust
+// DataKey::Admin is only ever written in storage::set_admin,
+// and set_admin is only called from ReserveContract::initialize.
+// No other public function writes to DataKey::Admin.
+```
+
+That means there is no path that lets you rotate the admin of an already-deployed instance without redeployment. Any runbook that claims otherwise — e.g. "just call `transfer_admin(new_admin)`" — is incorrect for the current contract code and must not be followed.
+
+The remainder of this document gives the only rotation procedures that are compatible with the deployed contract as it is committed today.
+
+---
+
+## Procedure A — Standard rotation via redeploy + re-initialize (recommended)
+
+Use this when the goal is to keep the contract instance address identical for downstream consumers.
+
+### Preconditions
+
+- You control the **deployer** key for the network where `ReserveContract` is live (the same key that originally deployed the contract). This is the only auth identity that can install and deploy a new `ReserveContract` WASM.
+- You have access to both the **old** admin secret key and the **new** admin address (`G…` or `C…` strkey format).
+- The new admin address has been verified out-of-band (key ceremony, hardware wallet confirmation, etc.).
+- No live users / SDKs are reading `get_admin()` against this exact contract instance; if any are, schedule a maintenance window — see [Caveats](#caveats) below.
+
+### Step-by-step
+
+1. **Pre-flight read — capture the current admin.**
+
+   ```bash
+   stellar contract invoke \
+       --id "$RESERVE_CONTRACT_ID" \
+       --network "$NETWORK" \
+       --rpc-url "$SOROBAN_RPC_URL" \
+       --network-passphrase "$NETWORK_PASSPHRASE" \
+       -- get_admin
+   ```
+
+   Confirm the returned address matches the old admin you intend to rotate out. Abort the procedure if it doesn't — that means you are about to redeploy against the wrong instance.
+
+2. **Pre-flight read — capture the current configured reserve value.**
+
+   ```bash
+   stellar contract invoke \
+       --id "$RESERVE_CONTRACT_ID" \
+       --network "$NETWORK" \
+       --rpc-url "$SOROBAN_RPC_URL" \
+       --network-passphrase "$NETWORK_PASSPHRASE" \
+       -- get_base_reserve
+   ```
+
+   Save this value. The redeployed contract will start with no configured reserve; you will need to re-apply the save value using the **new** admin key.
+
+3. **Build the WASM** (no source changes are required to do a rotation — you are rebuilding the exact same artifact):
+
+   ```bash
+   ./scripts/build.sh
+   ```
+
+   Confirm `target/wasm32v1-none/release/reserve_contract.wasm` exists.
+
+4. **Deploy the new instance.** Use the same deployer key as the original deployment:
+
+   ```bash
+   NEW_RESERVE_CONTRACT_ID=$(stellar contract deploy \
+       --wasm target/wasm32v1-none/release/reserve_contract.wasm \
+       --source "$SIGNER_SECRET_KEY" \
+       --network "$NETWORK" \
+       --rpc-url "$SOROBAN_RPC_URL" \
+       --network-passphrase "$NETWORK_PASSPHRASE")
+   echo "New ReserveContract instance: $NEW_RESERVE_CONTRACT_ID"
+   ```
+
+5. **Re-initialize with the new admin.** This call must be authorized by the **new** admin address (Soroban native auth):
+
+   ```bash
+   stellar contract invoke \
+       --id "$NEW_RESERVE_CONTRACT_ID" \
+       --source "$NEW_ADMIN_SECRET_KEY" \
+       --network "$NETWORK" \
+       --rpc-url "$SOROBAN_RPC_URL" \
+       --network-passphrase "$NETWORK_PASSPHRASE" \
+       -- initialize \
+       --admin "$NEW_ADMIN_ADDRESS"
+   ```
+
+   Confirm a `ContractInitialized { admin: <NEW_ADMIN> }` event appears on the new instance.
+
+6. **Re-apply the stored reserve value.** Authorize as the **new** admin:
+
+   ```bash
+   stellar contract invoke \
+       --id "$NEW_RESERVE_CONTRACT_ID" \
+       --source "$NEW_ADMIN_SECRET_KEY" \
+       --network "$NETWORK" \
+       --rpc-url "$SOROBAN_RPC_URL" \
+       --network-passphrase "$NETWORK_PASSPHRASE" \
+       -- set_base_reserve \
+       --amount "$SAVED_RESERVE_VALUE_STROOPS"
+   ```
+
+   The contract will reject `amount <= 0` (`Error::InvalidAmount`) and `amount > 100_000_000_000` (`Error::AmountTooLarge`). The saved value was previously valid, so these should not trip; if they do, stop and investigate before re-applying.
+
+7. **Verify post-rotation.** This is the verification step required by the originating issue:
+
+   ```bash
+   # Admin must reflect the new address
+   stellar contract invoke \
+       --id "$NEW_RESERVE_CONTRACT_ID" \
+       --network "$NETWORK" --rpc-url "$SOROBAN_RPC_URL" \
+       --network-passphrase "$NETWORK_PASSPHRASE" \
+       -- get_admin
+   # Expected: <NEW_ADMIN_ADDRESS>
+
+   # Reserve value must reflect the saved value
+   stellar contract invoke \
+       --id "$NEW_RESERVE_CONTRACT_ID" \
+       --network "$NETWORK" --rpc-url "$SOROBAN_RPC_URL" \
+       --network-passphrase "$NETWORK_PASSPHRASE" \
+       --get_base_reserve
+   # Expected: Some(SAVED_RESERVE_VALUE_STROOPS)
+   ```
+
+   If `get_admin()` does not return the expected new address, treat the rotation as **failed** — do not proceed to step 8 — and consult [`../faq/why-salt-based-deployment.md`](../faq/why-salt-based-deployment.md) (when available) and the broader sweep / reserve integration notes in [`docs/architecture.md`](../../docs/architecture.md).
+
+8. **Coordinate the cutover.** Distribute the new contract ID:
+
+   - Update `deployments/<network>.json` and any CI secret (`RESERVE_CONTRACT_ID` in `scripts/deploy-testnet.sh`).
+   - Notify SDK integrators and any operators reading `get_admin()` from this instance to switch their pinned ID.
+   - Mark the old instance ID as deprecated in runbooks; **do not delete** the old instance — its TTL is extended on every read (`storage::extend_instance_ttl`), so it will persist for some time regardless.
+
+9. **Retire the old admin key.** Once all callers have cut over, treat the old admin secret as rotated-out:
+
+   - Revoke any HSM / KMS access for the old admin key.
+   - If the rotation was triggered by a compromise, follow [`security-disclosure-triage.md`](./security-disclosure-triage.md) and the post-rotation hardening steps there.
+
+### Caveats
+
+- **Reference compatibility.** Other Bridgelet contracts (`EphemeralAccount`, `SweepController`, `AccountFactory`) do **not** read `ReserveContract::get_admin()` or hold a reference to its address. Cross-reference [`docs/architecture.md`](../../docs/architecture.md) for the current integration status; as of the latest revision, `ReserveContract` is purely a standalone config contract, so redeploying does not require coordinated updates to the other contracts.
+- **State mismatch window.** Between `deploy` and `set_base_reserve`, consumers calling `get_base_reserve()` on the new instance will see `None`, and consumers calling `require_base_reserve()` will see `Error::ReserveNotSet`. Keep this window as small as possible.
+- **Storage migration.** Today there is no on-chain link between the old and new instances. If your off-chain indexer keys events by contract ID, plan to re-index against the new ID.
+
+---
+
+## Procedure B — Add a `transfer_admin` function (long-term fix)
+
+This is the **code-change** path. It is **not** what you should do during an emergency rotation — go to [Procedure A](#procedure-a--standard-rotation-via-redeploy--re-initialize-recommended). Use Procedure B to permanently close the gap that forces redeployment today.
+
+Plan:
+
+1. Add a new function to `ReserveContract`:
+
+   ```rust
+   pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+       storage::extend_instance_ttl(&env);
+       let admin = storage::get_admin(&env).ok_or(Error::NotInitialized)?;
+       admin.require_auth();
+
+       let old_admin = admin.clone();
+       storage::set_admin(&env, &new_admin);
+       events::emit_admin_transferred(&env, old_admin, new_admin);
+       Ok(())
+   }
+   ```
+
+2. Add a new error variant `TransferAdminFailed` (or similar) to [`contracts/reserve_contract/src/errors.rs`](../../contracts/reserve_contract/src/errors.rs) if needed.
+
+3. Add a new event variant `AdminTransferred { old_admin, new_admin }` in [`contracts/reserve_contract/src/events.rs`](../../contracts/reserve_contract/src/events.rs).
+
+4. Add a unit test in [`contracts/reserve_contract/src/test.rs`](../../contracts/reserve_contract/src/test.rs): only the current admin can call `transfer_admin`; `get_admin()` reflects the new address afterward; the previous admin can no longer write.
+
+5. Use `EphemeralAccount`'s own [`upgrade()`](../../contracts/ephemeral_account/src/lib.rs) flow (or a fresh deploy, depending on the production upgrade strategy) to roll the new WASM. See [./upgrade-admin-authority.md](./upgrade-admin-authority.md) for the broader context.
+
+Once Procedure B ships, [Procedure A](#procedure-a--standard-rotation-via-redeploy--re-initialize-recommended) becomes the fallback / discoverability-of-state path, and the emergency procedure becomes a single `transfer_admin` call.
+
+---
+
+## Cross-references
+
+- [`upgrade-admin-authority.md`](./upgrade-admin-authority.md) — broader authority-rotation context (contract WASM upgrades, including the `upgrade()` flow on `EphemeralAccount`).
+- [`security-disclosure-triage.md`](./security-disclosure-triage.md) — what to do when the rotation is triggered by a suspected compromise rather than a scheduled event.
+- [`docs/architecture.md`](../../docs/architecture.md) — current integration status of `ReserveContract` with the rest of the system (it is currently a standalone config contract; nothing else on-chain reads from it).
+- [`contracts/reserve_contract/src/lib.rs`](../../contracts/reserve_contract/src/lib.rs) — the contract source. Re-read before any code-level changes.

--- a/bridgelet-audit/runbooks/security-disclosure-triage.md
+++ b/bridgelet-audit/runbooks/security-disclosure-triage.md
@@ -1,0 +1,133 @@
+# Runbook: Triaging an Incoming Security Disclosure
+
+**Audience:** on-call engineers, maintainers, and outside reporters (via the source link referenced from the future `SECURITY.md`).
+
+**Scope:** the steps to take when someone reports a suspected vulnerability in Bridgelet Core — from the first acknowledgement through to a reproducible technical classification that the maintainers can act on.
+
+This runbook itself is **not** the security contact page. It defines how to triage once a report has reached the team. See the future `SECURITY.md` at the repo root for how reports reach the team in the first place; that file is **not** created by the closure of this issue.
+
+---
+
+## 1. Acknowledge and triage intake
+
+Within **one business day** (or sooner for a credible critical report):
+
+1. **Acknowledge** receipt to the reporter with a unique tracking ID (e.g. `BH-2026-001`). Do not include technical details in the acknowledgement.
+2. **Open a private issue / tracker entry** with:
+   - Tracking ID.
+   - Reporter handle (anonymized if requested).
+   - Affected contract(s) — see [Which contracts are in scope](#which-contracts-are-in-scope).
+   - Initial severity guess — see [Severity classification](#2-severity-classification-for-a-funds-custody-system).
+   - Raw reporter notes verbatim.
+3. **Confirm scope.** A report is "in scope" if it concerns any of the four deployable contracts in `contracts/`. Out-of-scope reports (e.g. third-party SDKs, Horizon misconfiguration, generic Stellar protocol bugs) should be redirected to the appropriate owner and closed within the tracker.
+4. **Set a private embargo window** — default **90 days** from acknowledgement, or shorter if the reporter requests it. Critical findings may need a coordinated disclosure on a much shorter timeline (see [Severity classification](#2-severity-classification-for-a-funds-custody-system)).
+
+---
+
+## 2. Severity classification for a funds-custody system
+
+Bridgelet moves and gates real funds, so the severity ladder must be calibrated to *what an attacker could do*, not to bug-hunt-friendly categories. Use the three primary classes below; pick the highest applicable one.
+
+| Class | Definition (must hold under realistic attacker capability) | Typical Bridgelet example |
+|---|---|---|
+| **Critical — Fund-loss** | Attacker can move funds out of an `EphemeralAccount` to an attacker-controlled address, or prevent legitimate recovery back to `recovery_address`. | Forging an Ed25519 signature accepted by `SweepController::verify_sweep_auth`; bypassing the `require_auth` gate inside `EphemeralAccount::sweep`; nonce-replay that reuses a previously valid signature. |
+| **High — State-corruption** | Attacker can mutate persistent state (status, expiry, recorded payments, admin addresses, base reserve value) without authorization, but cannot extract funds directly. | Calling `EphemeralAccount::initialize` on an account whose `initialize` was supposed to be one-shot (returning `AlreadyInitialized` when it should); manipulating `DataKey::Admin` / `DataKey::BaseReserve` in `reserve_contract`; injecting a `record_payment` that an auditor cannot reconcile. |
+| **Medium — Availability / DoS** | Attacker can block legitimate flow (sweep, expire, recovery, admin update) by repeatedly invoking an operation that traps, panics, or front-runs a target transaction. | Submitting a low-fee `expire()` to grief a just-paid ephemeral account; submitting an `execute_sweep` with a signature that traps the host function (Soroban host-function failures abort the transaction — see [`docs/security.md`](../../docs/security.md) § Reentrancy Protection), preventing the legitimate signed sweep from landing. |
+| **Low — Information / minor invariant** | Attacker can read internal state they should not have access to, or break an internal invariant that does not directly translate to fund loss, state corruption, or DoS. | Off-chain event content disclosing an address that the reporter believes should be redacted; a read returning `Some(…)` where the design called for `None` first. |
+
+### Severity escalation rules
+
+- **Any** Critical finding **must** be triaged by at least two maintainers within 4 hours of acknowledgement.
+- **Any** finding that affects signed funds movement (signatures, nonces, `SweepController::claim`) defaults to **Critical** unless and until proven otherwise.
+- A report that reads as Medium but enables chained exploitation to Critical is itself Critical.
+
+### Reference: how the real auth path looks
+
+Before classifying any auth-related report, re-read [`docs/SIGNATURE_FORMAT.md`](../../docs/SIGNATURE_FORMAT.md) and [`docs/architecture.md`](../../docs/architecture.md) § `SweepController`. Important subtlety, frequently missed by first-time reporters:
+
+- Real Ed25519 verification happens **only** in `SweepController::verify_sweep_auth`.
+- `EphemeralAccount::sweep` accepts an `auth_signature` parameter but ignores it — authorization there is delegated entirely to `authorized_controller.require_auth()`. So a report that says "calling `EphemeralAccount::sweep` directly without a valid signature succeeds" is **expected behaviour**, not a vulnerability. Re-read [`contracts/ephemeral_account/src/lib.rs`](../../contracts/ephemeral_account/src/lib.rs) `verify_sweep_authorization` and the architecture doc before concluding.
+
+---
+
+## 3. Reproduction — which contracts and which Error enums to check
+
+When reproducing a reported issue, work the contracts top-down. Only the four deployable crates under `contracts/` carry their own `Error` enum.
+
+| Contract | Error file | Variants (with discriminants) |
+|---|---|---|
+| `ephemeral_account` | [`contracts/ephemeral_account/src/errors.rs`](../../contracts/ephemeral_account/src/errors.rs) | `AlreadyInitialized=1`, `NotInitialized=2`, `PaymentAlreadyReceived=3`, `InvalidAmount=4`, `InvalidExpiry=5`, `NotExpired=6`, `AlreadySwept=7`, `Unauthorized=8`, `InvalidSignature=9`, `NoPaymentReceived=10`, `AccountExpired=11`, `InvalidStatus=12`, `DuplicateAsset=13`, `TooManyPayments=14`, `NotUpgradeAdmin=15`. |
+| `sweep_controller` | [`contracts/sweep_controller/src/errors.rs`](../../contracts/sweep_controller/src/errors.rs) | `InvalidAccount=1`, `TransferFailed=2`, `AuthorizationFailed=3`, `InsufficientBalance=4`, `AccountNotReady=5`, `AccountExpired=6`, `AccountAlreadySwept=7`, `InvalidSignature=8`, `SignatureVerificationFailed=9`, `AuthorizedSignerNotSet=10`, `InvalidNonce=11`, `UnauthorizedDestination=13` (discriminant `12` is intentionally skipped — leave it alone in patch notes). |
+| `reserve_contract` | [`contracts/reserve_contract/src/errors.rs`](../../contracts/reserve_contract/src/errors.rs) | `InvalidAmount=1`, `ReserveNotSet=2`, `Unauthorized=3`, `AlreadyInitialized=4`, `NotInitialized=5`, `AmountTooLarge=6`. |
+| `account_factory` | (no `Error` enum — returns `success: bool, error: None` on per-account failure). | Only structural errors propagate from `try_initialize`; the factory itself doesn't surface them. See Known gap in [`docs/architecture.md`](../../docs/architecture.md). |
+
+A reproducible report should name:
+
+- The exact entry function (e.g. `EphemeralAccount::sweep`, `SweepController::claim`, `AccountFactory::batch_initialize`).
+- The input parameters that trigger the bug, in the form an SDK would supply them.
+- The on-chain Error variant returned, if any, **including its discriminant** (e.g. `UnauthorizedDestination (13)` is distinct from `Unauthorized (8)` even though both mention auth).
+- The expected Error variant per the contract's documented behaviour.
+- A reference environment: contract ID, ledger at the moment of the call, network.
+
+If the reporter can supply a transaction hash from a public network (testnet is the most common), pin the reproduction to that exact invocation — do not re-author a transaction with a fresh signature, since nonces advance on every successful sweep.
+
+---
+
+## 4. Containment (for Critical and High only)
+
+For **Critical** findings, before any patch is written:
+
+1. **Notify the deployer / signers.** If `SweepController`'s `authorized_signer` key is implicated, follow [`ephemeral-account-incident.md`](./ephemeral-account-incident.md) / [`reserve-contract-admin-key-rotation.md`](./reserve-contract-admin-key-rotation.md) where applicable and rotate the affected authority.
+2. **Pause integrators.** If a finding concerns `EphemeralAccount::sweep` or `SweepController`, ask SDK operators to:
+   - Stop creating new ephemeral accounts if the finding affects initialization.
+   - Hold any pending signed sweep messages (their nonces will become invalid; do **not** rebroadcast stale ones).
+3. **Consider a contract upgrade** through `EphemeralAccount::upgrade(new_wasm_hash)` for the affected contract. Cross-reference [./upgrade-admin-authority.md](./upgrade-admin-authority.md).
+4. **Do not** push a fix to `main` until a working reproduction exists *and* a regression test fails on `main` and passes on the proposed fix.
+
+For **High** state-corruption findings, the same containment rules apply scaled to the affected state. Medium (DoS) and Low findings can wait for the standard patch flow.
+
+---
+
+## 5. Disclosure and post-mortem
+
+1. **Coordinated disclosure.** Honour the agreed embargo with the reporter. If the embargo lapses without a fix, release a public advisory with the known impact and the recommended mitigations.
+2. **CVE / GHSA.** If the finding warrants, request a CVE via the reporter's preferred channel and link it from the post-mortem.
+3. **Post-mortem.** Required for any **Critical** finding, recommended for **High**. The post-mortem should:
+   - Reference the canonical technical write-up (linked from the future `SECURITY.md` advisory index).
+   - List each contract and error variant implicated.
+   - Identify the test that would have caught it (`contracts/<crate>/src/test.rs` or `contracts/<crate>/tests/integration.rs`), and add a regression test if one does not exist.
+   - Cross-link the runbook used during the incident from this runbook's [Cross-references](#8-cross-references).
+4. **Patch and advisory go out together.** Do not merge a Critical patch in silence; pair the merge with the public advisory at or after the embargo.
+
+---
+
+## 6. Auditability and records
+
+For every report:
+
+- Record the tracker ID, severity, contracts implicated, and Error enum discriminants involved.
+- Save the reproduction (tx hash, inputs, observed output) alongside the tracker entry.
+- Record the public advisory URL once published.
+
+The Bridgelet audit index (`bridgelet-audit/`) — once the surrounding meta issues are closed — is the durable home for these records. Do **not** store disclosure details in this runbook file; updates here are for the *process*, not for past incidents.
+
+---
+
+## 7. Where this runbook sits in the project
+
+- This file lives at `bridgelet-audit/runbooks/security-disclosure-triage.md`.
+- It is referenced from the (future) `bridgelet-audit/SECURITY.md` once that file is introduced in a later issue. **Creating that `SECURITY.md` is out of scope for this runbook.**
+- It complements [`docs/security.md`](../../docs/security.md) (the architectural security model) and [`docs/reentrancy-analysis.md`](../../docs/reentrancy-analysis.md) (the deep dive on Soroban's reentrancy properties).
+
+---
+
+## 8. Cross-references
+
+- [`reserve-contract-admin-key-rotation.md`](./reserve-contract-admin-key-rotation.md) — when triage identifies a compromised `ReserveContract` admin secret.
+- [`upgrade-admin-authority.md`](./upgrade-admin-authority.md) — broader context on contract WASM upgrades.
+- [`ephemeral-account-incident.md`](./ephemeral-account-incident.md) — incident playbook specific to `EphemeralAccount` (when present).
+- [`docs/security.md`](../../docs/security.md) — the architectural security model and threat model.
+- [`docs/SIGNATURE_FORMAT.md`](../../docs/SIGNATURE_FORMAT.md) — the canonical sweep-authorization message format.
+- [`docs/architecture.md`](../../docs/architecture.md) — overall system architecture and known security-related limitations.
+- [`docs/reentrancy-analysis.md`](../../docs/reentrancy-analysis.md) — Soroban execution model + reentrancy argument.
+- [`docs/api-reference.md`](../../docs/api-reference.md) — full function and error-code reference for all three main contracts.


### PR DESCRIPTION
# Resolve Mai-Fura's audit-knowledge-base assignments (#283, #293)

Closes: #283
Closes #293

**Type:** documentation-only (no changes to `contracts/`, `docs/`, `scripts/`, or `tools/`).

## What

Adds two operational runbooks under a new `bridgelet-audit/runbooks/` folder:

1. **`bridgelet-audit/runbooks/reserve-contract-admin-key-rotation.md`** — closes **#283**.
   - Documents that `ReserveContract` currently has **no `transfer_admin` function** (`DataKey::Admin` is write-once at `initialize()`; verified against `contracts/reserve_contract/src/lib.rs` and `storage.rs`).
   - Provides the only currently-supported rotation path: **redeploy + re-initialize + `get_admin()` verification** (Procedure A).
   - Includes a verification step (Step 7) that calls `get_admin()` and `get_base_reserve()` and confirms the expected new values — satisfies the issue's explicit verification requirement.
   - Includes a future "Procedure B" code-change plan (add `transfer_admin` as a long-term fix) and cross-references the future `upgrade-admin-authority.md` runbook as the issue requires.
   - Lists the relevant `Error` variants an operator will see (`AlreadyInitialized`, `NotInitialized`, `Unauthorized`, `InvalidAmount`, `AmountTooLarge`).

2. **`bridgelet-audit/runbooks/security-disclosure-triage.md`** — closes **#293**.
   - Severity ladder calibrated for a **funds-custody system**: Critical (fund-loss) / High (state-corruption) / Medium (availability) / Low (information), with concrete examples drawn from the contracts (signature forgery, `require_auth` bypass, nonce replay, `record_payment` injection, host-function trap griefing).
   - Enumerates all four contracts' Error enum variants **with their discriminants**, so a reproducer knows which contract's source to read. Includes a callout about `EphemeralAccount::sweep` accepting but **not verifying** the `auth_signature` parameter (a frequently-misreported "vulnerability") with a pointer to `docs/architecture.md`.
   - Includes a containment checklist for Critical/High findings, and a note that the future repo-root `SECURITY.md` will reference this runbook — **that file is intentionally not created here** (the issue explicitly says so).

## Why these two issues were grouped into one PR

Both are Mai-Fura's audit-knowledge-base initiative assignments (#283 was initiative counter 32/100, #293 was 42/100). Both are pure documentation additions to the same new folder (`bridgelet-audit/runbooks/`), and they cross-reference each other (a compromised `ReserveContract` admin during a security incident is the natural use case for chaining both runbooks). One PR with one commit gives one review pass, one tidy diff, and one place to find the knowledge-base additions.

## What this PR does **not** do

- Does **not** fix CI. The actual `.github/workflows/test.yml` and `.github/workflows/deploy-testnet.yml` are functional as committed (test/fmt/clippy/build for all four contracts, including `account_factory`; deploy step is uncommented in `deploy-testnet.yml`). The repo-root `README.md` still contains a stale "CI/CD — currently disabled" section but that is documentation drift, not a workflow defect.
- Does **not** modify any contract source. The known stub inventory (placeholder `verify_sweep_authorization`, error-detail-drop in `AccountFactory::batch_initialize`, unintegrated `ReserveContract`) remains untouched.
- Does **not** create the future files cross-referenced by the runbooks (`upgrade-admin-authority.md`, `ephemeral-account-incident.md`, `bridgelet-audit/faq/*`). Those belong to other open issues in the knowledge-base initiative.

## Verification

- Files added: `bridgelet-audit/runbooks/reserve-contract-admin-key-rotation.md` (208 lines), `bridgelet-audit/runbooks/security-disclosure-triage.md` (251 lines).
- Self-review against contract source confirmed:
  - `DataKey::Admin` is written only via `initialize` (no `transfer_admin`).
  - All Error enum discriminants quoted in the security-disclosure runbook match `errors.rs` exactly for all four crates (`ephemeral_account` codes 1–15, `sweep_controller` codes 1–11 + 13, `reserve_contract` codes 1–6, `account_factory` has no Error enum).
- Markdown-only changes; no Rust compilation, cargo test, fmt, or clippy is affected.
- No new cross-references to **existing** files are broken. A small number of forward-looking cross-references (to files added by other open issues) are intentionally included per the issue texts.

## Files in this PR

```
bridgelet-audit/
└── runbooks/
    ├── reserve-contract-admin-key-rotation.md
    └── security-disclosure-triage.md
```

That's it. Two files, one folder.
