### PR TITLE
docs: add audit threat models, reserve reclaim glossary, and sync API…

### DIFF
--- a/bridgelet-audit/glossary/reserve-reclaim.md
+++ b/bridgelet-audit/glossary/reserve-reclaim.md
@@ -1,0 +1,102 @@
+# Glossary Entry: Reserve Reclaim Lifecycle
+
+**Path:** `bridgelet-audit/glossary/reserve-reclaim.md`  
+**Component:** `EphemeralAccount`  
+**Related Functions:** `reclaim_reserve()`, `reclaim_reserve_to()`, `get_reserve_remaining()`, `get_reserve_available()`, `is_reserve_reclaimed()`
+
+---
+
+## Overview
+
+The **Reserve Reclaim Lifecycle** governs how base-reserve XLM funds allocated to an `EphemeralAccount` contract upon deployment are tracked and recovered after the account's primary token lifecycle completes (via a sweep or expiration).
+
+In Stellar/Soroban, smart contracts hold a minimum balance (base reserve) denominated in stroops ($1 \text{ XLM} = 10^7 \text{ stroops}$, or $1_000_000_000$ stroops depending on contract configuration; `EphemeralAccount` uses `BASE_RESERVE_STROOPS = 1_000_000_000`). Once an account transitions to `Swept` or `Expired`, its base reserve is returned to the designated destination address.
+
+---
+
+## State Machine: `base_reserve_remaining` vs `available_reserve`
+
+The contract maintains two internal state variables for reserve accounting:
+
+1. **`base_reserve_remaining` (Total Left to Reclaim)**:
+   - Represents the total un-reclaimed reserve liability of the account.
+   - Initialized to `BASE_RESERVE_STROOPS` ($1_000_000_000$ stroops) upon contract `initialize()`.
+   - Monotonically decreases toward `0` as reserve payouts succeed.
+   - When `base_reserve_remaining == 0`, the flag `is_reserve_reclaimed` becomes `true`.
+
+2. **`available_reserve` (Currently Reclaimable)**:
+   - Represents the liquid XLM balance stroops currently present in the contract's local storage/balance buffer available for immediate payout.
+   - Initialized to `BASE_RESERVE_STROOPS` ($1_000_000_000$ stroops) upon contract `initialize()`.
+   - In partial-payout scenarios (e.g. if liquid balance was partially drawn or locked), `available_reserve` may temporarily be less than `base_reserve_remaining`.
+
+### Operational Formula for Reclaim Amount
+When `reclaim_reserve_to(env, destination, sweep_id)` is invoked:
+$$\text{reclaim\_amount} = \min(\text{available\_reserve}, \text{base\_reserve\_remaining})$$
+
+State updates applied atomically:
+$$\text{new\_available} = \text{available\_reserve} - \text{reclaim\_amount}$$
+$$\text{new\_remaining} = \text{base\_reserve\_remaining} - \text{reclaim\_amount}$$
+$$\text{fully\_reclaimed} = (\text{new\_remaining} == 0)$$
+
+---
+
+## Worked Example: Reclaim Lifecycle Walkthrough
+
+### Scenario
+An `EphemeralAccount` is initialized with $1_000_000_000$ stroops ($100 \text{ XLM}$ base reserve equivalent in test units).
+
+```
+Initial State:
+- status: Active
+- base_reserve_remaining: 1,000,000,000
+- available_reserve:      1,000,000,000
+- is_reserve_reclaimed:   false
+```
+
+### Call 1: Partial Reclaim (e.g., initial sweep with restricted available balance)
+Suppose `available_reserve` is capped at $400_000_000$ stroops at the time of sweep.
+- `sweep()` is called. `reclaim_reserve_to()` executes:
+  - $\text{reclaim\_amount} = \min(400_000_000, 1_000_000_000) = 400_000_000$
+  - `new_available` = $400_000_000 - 400_000_000 = 0$
+  - `new_remaining` = $1_000_000_000 - 400_000_000 = 600_000_000$
+  - `fully_reclaimed` = `false`
+- Event Emitted: `ReserveReclaimed { destination: G..., amount: 400000000, sweep_id: 101, fully_reclaimed: false, remaining_reserve: 600000000 }`
+- Result: Returns `Ok(400000000)`.
+
+### Call 2: Secondary Top-Up & Full Reclaim
+Additional reserve balance becomes available ($600_000_000$ stroops added to `available_reserve`).
+- `reclaim_reserve()` is invoked manually or by off-chain sweeper:
+  - $\text{reclaim\_amount} = \min(600_000_000, 600_000_000) = 600_000_000$
+  - `new_available` = $600_000_000 - 600_000_000 = 0$
+  - `new_remaining` = $600_000_000 - 600_000_000 = 0$
+  - `fully_reclaimed` = `true`
+- Event Emitted: `ReserveReclaimed { destination: G..., amount: 600000000, sweep_id: 101, fully_reclaimed: true, remaining_reserve: 0 }`
+- Result: Returns `Ok(600000000)`.
+
+### Call 3: Subsequent Call (No-Op)
+- `reclaim_reserve()` is called again on the fully reclaimed account:
+  - `base_reserve_remaining` is `0`.
+  - Event Emitted: `ReserveReclaimed { destination: G..., amount: 0, sweep_id: 101, fully_reclaimed: true, remaining_reserve: 0 }`
+  - Result: Returns `Ok(0)` without error or state mutation. Safe to call idempotently.
+
+---
+
+## Off-Chain Reconciliation: `ReserveReclaimed` Event Fields
+
+Each reserve reclaim execution publishes a `ReserveReclaimed` event for indexers and accounting services:
+
+| Field Name | Type | Description for Off-Chain Reconciliation |
+| :--- | :--- | :--- |
+| `destination` | `Address` | Wallet or contract address receiving the reclaimed XLM reserve stroops. Matches `swept_to` or `recovery_address`. |
+| `amount` | `i128` | Stroops transferred in *this specific transaction*. Used by bookkeepers to record exact incremental inflow. |
+| `sweep_id` | `u64` | Ledger sequence number at the time of sweep/expiration execution. Links the reserve payout to the specific sweep event. |
+| `fully_reclaimed` | `bool` | Flag indicating whether the reserve liability is completely cleared (`true`) or if outstanding reserve remains (`false`). |
+| `remaining_reserve` | `i128` | Outstanding reserve balance (in stroops) remaining on-chain after this call completes. |
+
+---
+
+## Key Security & Architecture Takeaways
+
+1. **Reentrancy Guard**: `EphemeralAccount` updates `status = Swept` / `Expired` *before* invoking `reclaim_reserve_to()`.
+2. **Idempotence**: `reclaim_reserve()` can be retried safely if network issues interrupt a multi-step settlement.
+3. **Auditability**: Total events emitted can be inspected via `get_reserve_reclaim_event_count()` and last event retrieved via `get_last_reserve_event()`.

--- a/bridgelet-audit/glossary/sweep-nonce.md
+++ b/bridgelet-audit/glossary/sweep-nonce.md
@@ -1,0 +1,30 @@
+# Glossary Entry: Sweep Nonce
+
+**Path:** `bridgelet-audit/glossary/sweep-nonce.md`  
+**Component:** `SweepController`  
+**Related Functions:** `execute_sweep()`, `get_nonce()`, `update_authorized_destination()`
+
+---
+
+## Overview
+
+The **Sweep Nonce** is a monotonically increasing 64-bit unsigned integer (`u64`) maintained by the `SweepController` contract instance. It provides cryptographic replay protection for off-chain Ed25519 sweep authorizations.
+
+---
+
+## Technical Mechanism
+
+1. **Initialization**: Set to `0` when `SweepController::initialize` is invoked.
+2. **Signature Payload Inclusion**: Off-chain signers must construct the cryptographic message digest as:
+   $$\text{message} = \text{SHA256}(\text{destination.to\_xdr()} \mathbin{\Vert} \text{nonce}_{\text{be\_u64}} \mathbin{\Vert} \text{controller\_id.to\_xdr()})$$
+3. **Verification & State Mutation**:
+   - During `execute_sweep()`, `SweepController` fetches its current stored nonce and verifies the signature against `message`.
+   - Upon successful signature verification, `SweepController` increments `nonce` (`nonce = nonce + 1`) **before** triggering downstream token transfers.
+4. **Replay Prevention**: Any attempt to replay the same signed message fails because the on-chain nonce has incremented, causing signature verification to fail (`Error::SignatureVerificationFailed`).
+
+---
+
+## Important Interactions & Known Behaviors
+
+- **`claim()` Interaction**: The gas-free `claim()` function uses Soroban native authorization (`recipient.require_auth()`) instead of an Ed25519 signature payload, and **does not** increment the controller's `sweep_nonce`.
+- **Destination Immutability Lock**: `update_authorized_destination()` checks `nonce > 0` to determine if a sweep has occurred and lock the authorized destination.

--- a/bridgelet-audit/glossary/sweep-vs-sweep-claim.md
+++ b/bridgelet-audit/glossary/sweep-vs-sweep-claim.md
@@ -1,0 +1,44 @@
+# Glossary Entry: `sweep` vs `sweep_claim`
+
+**Path:** `bridgelet-audit/glossary/sweep-vs-sweep-claim.md`  
+**Component:** `EphemeralAccount` & `SweepController`  
+**Related Functions:** `SweepController::execute_sweep()`, `SweepController::claim()`, `EphemeralAccount::sweep()`, `EphemeralAccount::sweep_claim()`
+
+---
+
+## Overview
+
+Bridgelet Core provides two execution pathways for sweeping funds from an `EphemeralAccount` to a recipient address:
+
+1. **Off-Chain Signed Sweep (`execute_sweep` / `EphemeralAccount::sweep`)**
+2. **Gas-Free Direct Claim (`claim` / `EphemeralAccount::sweep_claim`)**
+
+---
+
+## Direct Comparison Matrix
+
+| Feature / Property | `execute_sweep` (`sweep`) | `claim` (`sweep_claim`) |
+| :--- | :--- | :--- |
+| **Authentication Scheme** | Ed25519 signature verified in `SweepController` | Soroban native `require_auth()` signed by recipient |
+| **Relayer / Fee Payment** | Relayer submits tx with Ed25519 signature payload | Relayer submits tx; recipient signs Soroban auth entry |
+| **Mempool Parameter Locking** | `destination` locked cryptographically inside signature | Parameter passed explicitly; subject to frontrunning in flexible mode |
+| **Sweep Nonce Update** | Increments `SweepController` nonce on success | Does **not** increment `SweepController` nonce |
+| **Destination Lock Constraint** | Checks `authorized_destination` if set | Checks `authorized_destination` if set |
+| **Account State Machine** | Transitions `Active`/`PaymentReceived` $\rightarrow$ `Swept` | Transitions `Active`/`PaymentReceived` $\rightarrow$ `Swept` |
+
+---
+
+## Detailed Execution Patterns
+
+### 1. `execute_sweep` Pathway
+- Off-chain system signs `SHA256(destination || nonce || controller_id)`.
+- Invokes `SweepController::execute_sweep(ephemeral_account, destination, auth_signature)`.
+- `SweepController` verifies signature, increments sweep nonce, authorizes downstream invocation, and calls `EphemeralAccount::sweep()`.
+- `EphemeralAccount` marks state as `Swept`, reclaims reserve, and `SweepController` executes token transfers.
+
+### 2. `claim` Pathway
+- Recipient signs Soroban authorization entry for `SweepController::claim(recipient, ephemeral_account)`.
+- Relayer submits transaction and pays gas fees.
+- `SweepController` verifies `recipient.require_auth()` and checks `validate_destination()`.
+- `SweepController` invokes `EphemeralAccount::sweep_claim(recipient)` via invoker contract authorization context.
+- `EphemeralAccount` marks state as `Swept`, reclaims reserve, and `SweepController` executes token transfers.

--- a/bridgelet-audit/threat-models/frontrunning-risk.md
+++ b/bridgelet-audit/threat-models/frontrunning-risk.md
@@ -1,0 +1,80 @@
+# Threat Model: Mempool Frontrunning Risk Analysis on Sweep Transactions
+
+**Path:** `bridgelet-audit/threat-models/frontrunning-risk.md`  
+**Component:** `SweepController` & `EphemeralAccount`  
+**Target Operations:** `execute_sweep()`, `claim()`
+
+---
+
+## Executive Summary
+
+When a sweep transaction (`execute_sweep` or `claim`) is broadcast to the Stellar network, it enters the unconfirmed transaction pool (mempool) before ledger inclusion. The parameters—including `ephemeral_account`, `destination`, and signature payloads—are publicly visible to network nodes and potential frontrunners. 
+
+This analysis evaluates two primary threat vectors:
+1. **Payment Interception**: Can a frontrunner modify or copy a broadcast sweep transaction to divert funds to an attacker-controlled address?
+2. **Claim Preemption**: Can a frontrunner claim an active `EphemeralAccount` to their own wallet before the legitimate recipient's transaction lands on ledger?
+
+---
+
+## Detailed Threat Scenario & Vulnerability Analysis
+
+### Threat Scenario 1: Intercepting Payment in `execute_sweep`
+- **Mechanism**: The off-chain SDK/relayer submits `SweepController::execute_sweep(ephemeral_account, destination, auth_signature)`.
+- **Mempool Exposure**: Attacker observes the transaction parameters in the mempool.
+- **Attacker Strategy**: The attacker attempts to construct a modified transaction substituting `destination = attacker_address`.
+- **Outcome & Analysis**: **BLOCKED (Cryptographically Secured)**.
+  - The Ed25519 authorization signature is evaluated over:
+    $$\text{SHA256}(\text{destination.to\_xdr()} \mathbin{\Vert} \text{nonce}_{\text{be\_u64}} \mathbin{\Vert} \text{controller\_id.to\_xdr()})$$
+  - If the attacker changes `destination` to `attacker_address`, `SweepController::execute_sweep` invokes `AuthContext::verify()`, which fails with `Error::SignatureVerificationFailed` (or traps on host signature check).
+  - If the attacker replays the *exact same* transaction without modifying `destination`, the transaction executes with the legitimate `destination`. The attacker spends gas and achieves no theft.
+  - If `SweepController` is initialized in **Locked Mode** (`authorized_destination = Some(locked_addr)`), `validate_destination()` enforces `destination == locked_addr`, providing a second defense layer.
+
+---
+
+### Threat Scenario 2: Claim Preemption in `claim` (Gas-Free Path)
+- **Mechanism**: The recipient or relayer submits `SweepController::claim(recipient, ephemeral_account)`.
+- **Mempool Exposure**: Attacker observes `claim(legitimate_recipient, ephemeral_account)` in the mempool.
+- **Attacker Strategy**: The attacker immediately signs and submits `claim(attacker_address, ephemeral_account)` with higher transaction fee to land earlier in the same ledger block.
+- **Outcome & Analysis**: **VULNERABLE in Flexible Mode / PROTECTED in Locked Mode**.
+
+#### A. In Flexible Mode (`authorized_destination = None`)
+- `SweepController::claim` requires `recipient.require_auth()`. An attacker can generate a valid Soroban auth entry for their own address (`attacker_address`).
+- `claim` does **not** verify an Ed25519 signature from `authorized_signer`.
+- If `claim(attacker_address, ephemeral_account)` executes first:
+  1. `validate_destination()` passes (no destination lock set).
+  2. `EphemeralAccount::sweep_claim(attacker_address)` transitions account status to `Swept`.
+  3. All recorded token payments and base reserve are transferred to `attacker_address`.
+  4. The original transaction `claim(legitimate_recipient, ephemeral_account)` then reverts with `Error::AlreadySwept`.
+- **Result**: Frontrunner successfully steals all funds in flexible mode.
+
+#### B. In Locked Mode (`authorized_destination = Some(locked_address)`)
+- `validate_destination()` explicitly asserts `recipient == authorized_destination`.
+- If the attacker submits `claim(attacker_address, ephemeral_account)`, `validate_destination()` returns `Err(Error::UnauthorizedDestination)`.
+- **Result**: Frontrunning attempt fails; funds remain secure.
+
+---
+
+## Summary Matrix of Frontrunning Vectors
+
+| Pathway | Operating Mode | Frontrunner Action | Result / Impact | Security Status |
+| :--- | :--- | :--- | :--- | :--- |
+| `execute_sweep()` | Flexible or Locked | Change `destination` to attacker | Signature verification fails | **SECURE** |
+| `execute_sweep()` | Flexible or Locked | Replay original tx | Original destination receives funds | **SECURE** |
+| `claim()` | **Locked Mode** | Submit `claim(attacker, ephemeral)` | Fails with `UnauthorizedDestination` | **SECURE** |
+| `claim()` | **Flexible Mode** | Submit `claim(attacker, ephemeral)` | Account swept to attacker | **VULNERABLE** |
+
+---
+
+## Recommended Mitigations
+
+### 1. Mandate Locked Mode for `claim()` Invocations
+When utilizing the gas-free `claim()` interface, always initialize `SweepController` with `authorized_destination = Some(recipient_address)`. This guarantees that no third party can redirect funds via `claim()`.
+
+### 2. Restrict Flexible Mode to `execute_sweep()`
+If a application architecture requires dynamic/flexible destinations (where destination is not pre-set at initialization), **never use `claim()`**. Force all sweeps through `execute_sweep()`, which binds `destination` cryptographically inside the Ed25519 signature payload.
+
+### 3. Private RPC / Direct Validator Submission
+Relayers submitting `claim()` or `execute_sweep()` transactions should use private Horizon/RPC endpoints or direct validator submission channels (e.g. specialized transaction submission nodes) to prevent mempool snooping by sandwich/frontrunning bots.
+
+### 4. Recipient Authentication Payload Binding (Protocol Update)
+Future contract iterations of `SweepController::claim()` can accept an off-chain authorization voucher signed by `authorized_signer` binding `(recipient, ephemeral_account)`, ensuring even flexible-mode `claim()` calls cannot be hijacked by an arbitrary caller.

--- a/bridgelet-audit/threat-models/replay-nonce-protections.md
+++ b/bridgelet-audit/threat-models/replay-nonce-protections.md
@@ -1,0 +1,74 @@
+# Threat Model: Replay and Nonce Protections Across Bridgelet Core
+
+**Path:** `bridgelet-audit/threat-models/replay-nonce-protections.md`  
+**Component:** System-wide (`SweepController`, `EphemeralAccount`, `AccountFactory`)  
+**Cross-References:**
+- [reserve-reclaim.md](file:///c:/Users/g-obiagazie/Desktop/bridgelet-core/bridgelet-audit/glossary/reserve-reclaim.md)
+- [sweep-nonce.md](file:///c:/Users/g-obiagazie/Desktop/bridgelet-core/bridgelet-audit/glossary/sweep-nonce.md)
+- [sweep-vs-sweep-claim.md](file:///c:/Users/g-obiagazie/Desktop/bridgelet-core/bridgelet-audit/glossary/sweep-vs-sweep-claim.md)
+
+---
+
+## Executive Summary
+
+Replay attacks represent a primary vector for smart contract exploits, wherein an attacker captures a valid payload or signature and re-submits it to execute unauthorized operations or double-spend assets. Bridgelet Core implements a multi-layered defense using three distinct replay-prevention mechanisms operating at different layers of the stack:
+
+1. **Sweep Nonce** (`SweepController`): Monotonically increasing on-chain sequence counter protecting off-chain Ed25519 signature authorizations.
+2. **`AlreadySwept` State Guard** (`EphemeralAccount`): On-chain state machine enforcing single-use execution per ephemeral account instance.
+3. **Deployment Salt** (`AccountFactory`): Deterministic salt derivation used for WASM contract address creation.
+
+---
+
+## Mechanism Breakdown & Coverage Matrix
+
+### 1. Sweep Nonce Mechanism
+- **Scope & Storage**: Stored as `u64` in `SweepController` instance storage (`init_sweep_nonce`, `get_sweep_nonce`).
+- **Operation**: Included in SHA256 digest: `SHA256(destination || nonce || controller_id)`. Upon successful signature verification in `execute_sweep()`, `nonce` increments by 1.
+- **Threat Mitigated**: Prevents an attacker from capturing an Ed25519 signature payload submitted in transaction $T_1$ and replaying it in transaction $T_2$ to sweep another account or re-sweep the same controller.
+
+### 2. `AlreadySwept` Status Guard Mechanism
+- **Scope & Storage**: Stored as `AccountStatus` enum in `EphemeralAccount` contract storage.
+- **Operation**: Initialized to `Active` (0), transitions to `PaymentReceived` (1) on first payment, and explicitly transitions to `Swept` (2) or `Expired` (3) before token transfers or reserve reclaims execute.
+- **Threat Mitigated**: Prevents double-sweeping of an `EphemeralAccount`. Any subsequent attempt to invoke `sweep()` or `sweep_claim()` on an already-swept account immediately fails with `Error::AlreadySwept`.
+
+### 3. Deployment Salt Mechanism
+- **Scope & Storage**: Derived in `AccountFactory::batch_initialize` via `env.deployer().with_current_contract(salt).deploy_v2(...)`.
+- **Operation**: Constructing 32-byte salt `salt_bytes[28..32] = index.to_be_bytes()` to deterministically calculate new contract addresses.
+- **Threat Mitigated**: Prevents address collision within a single batch deployment call.
+
+---
+
+## Complete Matrix: Coverage by System Flow
+
+| Flow / System Operation | Sweep Nonce Covered? | `AlreadySwept` Guard Covered? | Deployment Salt Covered? | Status & Vulnerability Analysis |
+| :--- | :--- | :--- | :--- | :--- |
+| **`execute_sweep()`** | **Yes** (Verifies & Increments) | **Yes** (`EphemeralAccount` checks state) | N/A | **Fully Covered**: Signature replay impossible; double-sweep blocked. |
+| **`claim()` (Gas-Free Path)** | **No** (Nonce is not incremented) | **Yes** (`EphemeralAccount` checks state) | N/A | **Partially Covered**: State guard prevents double-sweep, but un-incremented nonce leaves `update_authorized_destination` check unlocked. |
+| **`record_payment()`** | N/A | N/A | N/A | **Partially Covered**: Guarded against duplicate assets (max 10), but accepts arbitrary inbound caller deposits. |
+| **`expire()` / `recover()`** | N/A | **Yes** (Fails if `Swept` or `Expired`) | N/A | **Fully Covered**: Immutable state transition prevents re-expiration or double reserve reclaim. |
+| **`reclaim_reserve()`** | N/A | **Yes** (State machine + `remaining_reserve` tracking) | N/A | **Fully Covered**: Idempotent payout formula $\min(\text{available}, \text{remaining})$ prevents double-payout. |
+| **`batch_initialize()`** | N/A | N/A | **Partial** (Index-scoped only) | **Gap Identified**: Index-based salt `0..N` repeats across separate batch transactions, causing salt collision if factory is invoked multiple times. |
+
+---
+
+## Identified Coverage Gaps & Architectural Recommendations
+
+### Gap 1: `claim()` Path Does Not Increment Sweep Nonce
+- **Analysis**: `SweepController::claim()` invokes `authorize_claim()` and calls `EphemeralAccount::sweep_claim()`. It skips `authorization::increment_nonce()`.
+- **Impact**: `update_authorized_destination()` checks `nonce > 0` to verify if sweeps have occurred. If all sweeps were executed via `claim()`, `nonce` remains `0`, allowing the creator to mutate `authorized_destination` after funds have already been claimed.
+- **Mitigation**: Update `claim()` to increment `sweep_nonce` or implement a dedicated `swept_count` flag on `SweepController`.
+
+### Gap 2: Cross-Transaction Salt Collision in `AccountFactory`
+- **Analysis**: `batch_initialize()` constructs `salt_bytes[28..32] = (index as u32).to_be_bytes()`. On a subsequent call to `batch_initialize()`, `index` resets to `0`, generating identical salts.
+- **Impact**: Deploying contracts with identical salts under the same factory address causes transaction failure or deployment collisions on ledger.
+- **Mitigation**: Mix a global factory deployment counter or unique request hash into `salt_bytes`:
+  $$\text{salt} = \text{SHA256}(\text{factory\_nonce} \mathbin{\Vert} \text{request\_hash} \mathbin{\Vert} \text{index})$$
+
+---
+
+## Summary & Cross-References
+
+For deep dives into individual lifecycle components, refer to:
+- [sweep-nonce.md](file:///c:/Users/g-obiagazie/Desktop/bridgelet-core/bridgelet-audit/glossary/sweep-nonce.md) for full specification of Ed25519 signature payload hashing.
+- [sweep-vs-sweep-claim.md](file:///c:/Users/g-obiagazie/Desktop/bridgelet-core/bridgelet-audit/glossary/sweep-vs-sweep-claim.md) for structural differences between signed sweeps and gas-free claims.
+- [reserve-reclaim.md](file:///c:/Users/g-obiagazie/Desktop/bridgelet-core/bridgelet-audit/glossary/reserve-reclaim.md) for the reserve state machine.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,6 +21,7 @@ fn initialize(
     expiry_ledger: u32,
     recovery_address: Address,
     authorized_controller: Address,
+    admin: Address,
 ) -> Result<(), Error>
 ```
 
@@ -29,7 +30,8 @@ fn initialize(
 | `creator` | `Address` | The account that created this contract. Must authorize this call. |
 | `expiry_ledger` | `u32` | Ledger sequence number at which the account expires. Must be in the future. |
 | `recovery_address` | `Address` | Address that receives funds if the account expires without being swept. |
-| `authorized_controller` | `Address` | The `SweepController` contract address authorized to call `sweep()` on behalf of this account. |
+| `authorized_controller` | `Address` | The `SweepController` contract address authorized to call `sweep()` / `sweep_claim()` on behalf of this account. |
+| `admin` | `Address` | Address authorized to perform WASM contract upgrades (`upgrade`). |
 
 **Returns:** `Ok(())` on success.
 
@@ -393,7 +395,7 @@ The nonce is incremented after each successful `execute_sweep` call to prevent r
 
 Gas-free claim path for the recipient. The recipient signs a Soroban auth entry for `claim(recipient, ephemeral_account)` only; a relayer or SDK submits the transaction and pays fees.
 
-Internally the controller uses `authorize_as_current_contract()` to satisfy `authorized_controller.require_auth()` inside `EphemeralAccount::sweep()`.
+Internally the controller validates destination (against `authorized_destination` if set) and uses `authorize_as_current_contract()` to invoke `EphemeralAccount::sweep_claim()`. Note that in flexible mode (`authorized_destination = None`), `claim` relies on `recipient.require_auth()` and does not enforce an Ed25519 signature payload.
 
 ```rust
 fn claim(env: Env, recipient: Address, ephemeral_account: Address) -> Result<(), Error>
@@ -413,6 +415,8 @@ fn claim(env: Env, recipient: Address, ephemeral_account: Address) -> Result<(),
 | `UnauthorizedDestination` | Controller is in locked mode and `recipient` ≠ `authorized_destination`. |
 
 **Auth required:** `recipient.require_auth()`
+
+**Nonce impact:** `claim()` does **not** increment `SweepController`'s `sweep_nonce`.
 
 **Events emitted:** `SweepCompleted { ephemeral_account, destination: recipient, amount }`
 
@@ -434,7 +438,9 @@ fn can_sweep(env: Env, ephemeral_account: Address) -> bool
 
 #### `update_authorized_destination`
 
-Allows the creator to update the locked destination before any sweep has occurred. Fails if a sweep has already been executed (nonce > 0).
+Allows the creator to update the locked destination before any signed sweep has occurred. Checks that `nonce == 0` (returns `AccountAlreadySwept` if `nonce > 0`).
+
+> **Note on Nonce Tracking:** Because `execute_sweep()` increments `nonce` on success while `claim()` does not currently increment `nonce`, this guard specifically tracks whether `execute_sweep()` has been executed. If accounts were swept exclusively via `claim()`, `nonce` remains `0`.
 
 ```rust
 fn update_authorized_destination(env: Env, new_destination: Address) -> Result<(), Error>
@@ -451,7 +457,7 @@ fn update_authorized_destination(env: Env, new_destination: Address) -> Result<(
 | Error | Condition |
 | :--- | :--- |
 | `AuthorizationFailed` | Caller is not the creator or controller is not initialized. |
-| `AccountAlreadySwept` | At least one sweep has been executed (nonce > 0); destination is now immutable. |
+| `AccountAlreadySwept` | At least one signed sweep has been executed (nonce > 0); destination is now immutable. |
 
 **Auth required:** `creator.require_auth()`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,11 +237,15 @@ fn update_authorized_destination(env: Env, new_destination: Address) -> Result<(
 
 `transfers::execute_transfers()` iterates every `Payment` returned by `EphemeralAccount::get_info()` and calls `TokenClient::new(env, &payment.asset).transfer(from, destination, &payment.amount)` for each — atomic multi-asset sweep in one call.
 
-#### `claim()` — gas-free path
+#### `claim()` — gas-free path & frontrunning considerations
 `recipient.require_auth()` (Soroban native auth on the outer transaction) replaces the Ed25519 signature entirely; the controller then authorizes itself as invoker of `EphemeralAccount::sweep_claim()`. This lets a relayer submit and pay fees while only the recipient signs.
 
+> **Security & Nonce Note:** 
+> 1. `claim()` does **not** increment `SweepController`'s `sweep_nonce`. Because `update_authorized_destination()` checks `nonce > 0` to lock destination updates, executing sweeps exclusively via `claim()` leaves `nonce == 0`, allowing destination updates to occur after a claim.
+> 2. In **Flexible Mode** (`authorized_destination = None`), `claim()` does not verify an Ed25519 signature and relies solely on `recipient.require_auth()`. A frontrunner in the mempool observing `claim(legitimate_recipient, ephemeral)` could submit `claim(attacker, ephemeral)` with a higher fee to sweep funds to themselves. In **Locked Mode** (`authorized_destination = Some(...)`), frontrunning is prevented as `validate_destination()` enforces `recipient == authorized_destination`.
+
 #### Destination locking
-If `authorized_destination` was set at `initialize()`, every `execute_sweep`/`claim` call is checked against it (`validate_destination`) and can be changed via `update_authorized_destination()` — but only before any sweep has occurred (`nonce == 0` check).
+If `authorized_destination` was set at `initialize()`, every `execute_sweep`/`claim` call is checked against it (`validate_destination`) and can be changed via `update_authorized_destination()` — but only before any signed sweep has occurred (`nonce == 0` check).
 
 #### Errors
 `InvalidAccount, TransferFailed, AuthorizationFailed, InsufficientBalance, AccountNotReady, AccountExpired, AccountAlreadySwept, InvalidSignature, SignatureVerificationFailed, AuthorizedSignerNotSet, InvalidNonce, UnauthorizedDestination` (discriminant `12` is unused/skipped — likely a removed variant; harmless in Rust but worth a cleanup pass).
@@ -280,9 +284,11 @@ fn batch_initialize(
 ) -> Vec<AccountInitResult>;
 ```
 
-Deploys a new `ephemeral_account` instance per request via `env.deployer().with_current_contract(salt).deploy_v2(...)`, using an index-derived salt, then calls `try_initialize()` on each. All accounts created this way get `authorized_controller = creator` and `admin = creator` (the factory passes `creator` for both of the last two `initialize` args).
+Deploys a new `ephemeral_account` instance per request via `env.deployer().with_current_contract(salt).deploy_v2(...)`, using an index-derived salt (`salt_bytes[28..32] = index as u32`), then calls `try_initialize()` on each. All accounts created this way get `authorized_controller = creator` and `admin = creator` (the factory passes `creator` for both of the last two `initialize` args).
 
-**Known gap:** on a per-account failure, `AccountInitResult.error` is hardcoded to `None` (see inline comment: *"In a real implementation, we'd serialize errors"*). Callers can detect `success: false` but not the cause.
+**Known gaps & Security Notes:**
+1. **Salt Collision Vulnerability:** `batch_initialize()` derives salts using only the loop index `0..requests.len()`. On subsequent calls to `batch_initialize()`, the loop indices reset to `0`, generating identical salts. Deploying contracts with identical salts under the same factory address causes transaction failure or address collisions.
+2. **Error Suppression:** On a per-account failure, `AccountInitResult.error` is hardcoded to `None` (see inline comment: *"In a real implementation, we'd serialize errors"*). Callers can detect `success: false` but not the cause.
 
 **Not wired into tooling:** not built by `scripts/build.sh`, not deployed by `scripts/deploy-testnet.sh`, not covered by either CI workflow.
 


### PR DESCRIPTION
…/architecture docs

closes #131 
closes #251 
closes #263 
closes #275 