### PR TITLE
feat: centralize shared storage keys, errors, types, and network passphrase check

### DIFF
--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -16,6 +16,10 @@ pub use events::{
 };
 pub use storage::DataKey;
 
+/// Expected network passphrase for this deployment.
+/// Change to `PUBLIC_NETWORK_PASSPHRASE` for mainnet.
+const EXPECTED_PASSPHRASE: &str = bridgelet_shared::passphrase::STANDALONE_PASSPHRASE;
+
 const BASE_RESERVE_STROOPS: i128 = 1_000_000_000;
 
 #[contract]
@@ -47,6 +51,10 @@ impl EphemeralAccountContract {
 
         // Verify creator authorization
         creator.require_auth();
+
+        // Enforce deploy-time network passphrase to prevent accidental testnet→mainnet deployment
+        bridgelet_shared::passphrase::require_network(&env, EXPECTED_PASSPHRASE)
+            .map_err(|_| Error::Unauthorized)?;
 
         // Validate expiry is in future
         let current_ledger = env.ledger().sequence();

--- a/contracts/shared/src/errors.rs
+++ b/contracts/shared/src/errors.rs
@@ -1,0 +1,105 @@
+use soroban_sdk::contracterror;
+
+/// Error variants shared across bridgelet contracts.
+///
+/// Both `ephemeral_account` and `sweep_controller` can encounter the same
+/// failure modes (not initialized, already initialized, unauthorized, expired).
+/// Centralising them here avoids duplicate numeric codes and ensures the SDK
+/// can interpret errors from either contract with a single enum.
+///
+/// Contract-specific errors remain in their respective `errors.rs` files and
+/// are re-exported from there.  Only errors that genuinely overlap belong
+/// here.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SharedError {
+    /// Contract has not been initialized yet.
+    NotInitialized = 1,
+    /// Contract has already been initialized — double-init is forbidden.
+    AlreadyInitialized = 2,
+    /// Caller is not authorized to perform this action.
+    Unauthorized = 3,
+    /// The operation is only valid before the account has expired.
+    Expired = 4,
+    /// The operation is only valid after the account has expired.
+    NotExpired = 5,
+    /// An arithmetic overflow or underflow was detected.
+    Overflow = 6,
+    /// The provided amount is not positive (or is zero).
+    InvalidAmount = 7,
+}
+
+// ── Conversions ────────────────────────────────────────────────────────
+// Allow `?` propagation from shared errors into contract-specific error
+// enums that define the same variants.  Each contract implements
+// `From<SharedError>` so shared helper functions can return `SharedError`
+// and the caller's `?` operator will auto-convert.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_error_codes_are_unique() {
+        let codes = [
+            SharedError::NotInitialized as u32,
+            SharedError::AlreadyInitialized as u32,
+            SharedError::Unauthorized as u32,
+            SharedError::Expired as u32,
+            SharedError::NotExpired as u32,
+            SharedError::Overflow as u32,
+            SharedError::InvalidAmount as u32,
+        ];
+        let mut sorted = codes;
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), codes.len(), "duplicate SharedError discriminant");
+    }
+
+    #[test]
+    fn shared_error_codes_do_not_collide_with_ephemeral_account_errors() {
+        // ephemeral_account::Error starts at 1 and goes up to 15.
+        // SharedError variants must not reuse those codes when both
+        // errors are present in the same transaction.
+        let ephemeral_codes: std::vec::Vec<u32> = (1..=15).collect();
+        let shared_codes = [
+            SharedError::NotInitialized as u32,
+            SharedError::AlreadyInitialized as u32,
+            SharedError::Unauthorized as u32,
+            SharedError::Expired as u32,
+            SharedError::NotExpired as u32,
+            SharedError::Overflow as u32,
+            SharedError::InvalidAmount as u32,
+        ];
+        for code in &shared_codes {
+            assert!(
+                !ephemeral_codes.contains(code),
+                "SharedError code {} collides with ephemeral_account::Error",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn shared_error_codes_do_not_collide_with_sweep_controller_errors() {
+        // sweep_controller::Error has codes 1–13 (with gap at 12).
+        let sweep_codes: std::vec::Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13];
+        let shared_codes = [
+            SharedError::NotInitialized as u32,
+            SharedError::AlreadyInitialized as u32,
+            SharedError::Unauthorized as u32,
+            SharedError::Expired as u32,
+            SharedError::NotExpired as u32,
+            SharedError::Overflow as u32,
+            SharedError::InvalidAmount as u32,
+        ];
+        for code in &shared_codes {
+            assert!(
+                !sweep_codes.contains(code),
+                "SharedError code {} collides with sweep_controller::Error",
+                code
+            );
+        }
+    }
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,5 +1,13 @@
 #![no_std]
 
+pub mod errors;
+pub mod passphrase;
+pub mod storage_keys;
 mod types;
 
-pub use types::{AccountInfo, AccountInitRequest, AccountInitResult, AccountStatus, Payment};
+pub use errors::SharedError;
+pub use storage_keys::StorageKey;
+pub use types::{
+    AccountInfo, AccountInitRequest, AccountInitResult, AccountStatus, AssetBalance,
+    ContractVersion, Payment, SweepPayload,
+};

--- a/contracts/shared/src/passphrase.rs
+++ b/contracts/shared/src/passphrase.rs
@@ -1,0 +1,74 @@
+use soroban_sdk::{Bytes, Env};
+
+/// well-known network passphrase constants (32-byte SHA-256 hashes are
+/// stored on-chain as `Bytes<32>`; the human-readable strings are what
+/// wallets sign against — we hash them here for comparison).
+
+/// Stellar Public Network passphrase
+pub const PUBLIC_NETWORK_PASSPHRASE: &str = "Public Global Stellar Network ; September 2015";
+
+/// Stellar Test Network passphrase
+pub const TESTNET_PASSPHRASE: &str = "Test SDF Network ; September 2015";
+
+/// Standalone (local sandbox) passphrase
+pub const STANDALONE_PASSPHRASE: &str = "Standalone Network ; February 2017";
+
+/// Hash a human-readable passphrase into the `Bytes<32>` format stored by
+/// `env.ledger().network_id()`.
+fn hash_passphrase(env: &Env, passphrase: &str) -> soroban_sdk::BytesN<32> {
+    let bytes = Bytes::from_slice(env, passphrase.as_bytes());
+    env.crypto().sha256(&bytes)
+}
+
+/// Verify that the current ledger's network passphrase matches one of the
+/// expected values.  Returns `Ok(())` on match, or `Err(expected_hash)`
+/// on mismatch so the caller can surface a meaningful error.
+///
+/// # Usage in `initialize()`
+/// ```ignore
+/// passphrase::require_network(&env, passphrase::TESTNET_PASSPHRASE)?;
+/// ```
+pub fn require_network(env: &Env, expected_passphrase: &str) -> Result<(), soroban_sdk::BytesN<32>> {
+    let actual = env.ledger().network_id();
+    let expected = hash_passphrase(env, expected_passphrase);
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(expected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_passphrase_deterministic() {
+        let env = Env::default();
+        let h1 = hash_passphrase(&env, TESTNET_PASSPHRASE);
+        let h2 = hash_passphrase(&env, TESTNET_PASSPHRASE);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_different_passphrases_produce_different_hashes() {
+        let env = Env::default();
+        let h_pub = hash_passphrase(&env, PUBLIC_NETWORK_PASSPHRASE);
+        let h_test = hash_passphrase(&env, TESTNET_PASSPHRASE);
+        assert_ne!(h_pub, h_test);
+    }
+
+    #[test]
+    fn test_require_network_passes_in_default_env() {
+        // Env::default() uses the standalone passphrase.
+        let env = Env::default();
+        assert!(require_network(&env, STANDALONE_PASSPHRASE).is_ok());
+    }
+
+    #[test]
+    fn test_require_network_fails_on_wrong_passphrase() {
+        let env = Env::default();
+        let result = require_network(&env, TESTNET_PASSPHRASE);
+        assert!(result.is_err());
+    }
+}

--- a/contracts/shared/src/storage_keys.rs
+++ b/contracts/shared/src/storage_keys.rs
@@ -1,0 +1,139 @@
+use soroban_sdk::contracttype;
+
+/// Canonical storage key enum shared across all bridgelet contracts.
+///
+/// Centralising key names here prevents typos, makes namespace auditing
+/// trivial, and ensures both contracts agree on the same storage layout
+/// for cross-contract reads.
+///
+/// Each contract maps these to its own concrete `DataKey` enum (or reuses
+/// this one directly) so that key values are consistent everywhere.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageKey {
+    /// Whether the contract has been initialized.
+    Initialized,
+    /// Address that deployed / created the contract instance.
+    Creator,
+    /// Ledger number at which an ephemeral account expires.
+    ExpiryLedger,
+    /// Address to which funds are returned on expiry.
+    RecoveryAddress,
+    /// Map of recorded payments (asset → Payment).
+    Payments,
+    /// Current lifecycle status of the account.
+    Status,
+    /// Destination the account was swept (or expired) to.
+    SweptTo,
+    /// Remaining base reserve in stroops.
+    BaseReserveRemaining,
+    /// Base reserve currently available for transfer.
+    AvailableReserve,
+    /// Whether the base reserve has been fully reclaimed.
+    ReserveReclaimed,
+    /// Sequence number of the last sweep operation.
+    LastSweepId,
+    /// Number of reserve reclaim events emitted.
+    ReserveEventCount,
+    /// Most recent ReserveReclaimed event payload.
+    LastReserveEvent,
+    /// Address of the authorized sweep controller.
+    AuthorizedController,
+    /// Admin address for contract upgrades.
+    Admin,
+    /// Ed25519 public key of the authorized off-chain signer.
+    AuthorizedSigner,
+    /// Monotonic nonce used to prevent replay of sweep signatures.
+    SweepNonce,
+    /// Locked destination address (optional, for locked-mode controllers).
+    AuthorizedDestination,
+    /// WASM hash stored by AccountFactory for deploying ephemeral accounts.
+    EphemeralAccountWasmHash,
+    /// Schema version used for storage migration (see #146).
+    StorageVersion,
+}
+
+// ── Convenience helpers ────────────────────────────────────────────────
+// These return the enum variants wrapped in `soroban_sdk::Val` via
+// `IntoVal` so callers can write `StorageKey::key_initialized()` instead
+// of constructing the `DataKey` variant every time.  They are purely
+// compile-time constants — no heap allocation.
+
+impl StorageKey {
+    pub fn key_initialized() -> Self {
+        Self::Initialized
+    }
+    pub fn key_creator() -> Self {
+        Self::Creator
+    }
+    pub fn key_expiry_ledger() -> Self {
+        Self::ExpiryLedger
+    }
+    pub fn key_status() -> Self {
+        Self::Status
+    }
+    pub fn key_payments() -> Self {
+        Self::Payments
+    }
+    pub fn key_authorized_signer() -> Self {
+        Self::AuthorizedSigner
+    }
+    pub fn key_sweep_nonce() -> Self {
+        Self::SweepNonce
+    }
+    pub fn key_storage_version() -> Self {
+        Self::StorageVersion
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that every variant has a distinct discriminant so Soroban
+    /// storage does not silently alias unrelated entries.
+    #[test]
+    fn storage_key_variants_are_distinct() {
+        let keys = [
+            StorageKey::Initialized as u32,
+            StorageKey::Creator as u32,
+            StorageKey::ExpiryLedger as u32,
+            StorageKey::RecoveryAddress as u32,
+            StorageKey::Payments as u32,
+            StorageKey::Status as u32,
+            StorageKey::SweptTo as u32,
+            StorageKey::BaseReserveRemaining as u32,
+            StorageKey::AvailableReserve as u32,
+            StorageKey::ReserveReclaimed as u32,
+            StorageKey::LastSweepId as u32,
+            StorageKey::ReserveEventCount as u32,
+            StorageKey::LastReserveEvent as u32,
+            StorageKey::AuthorizedController as u32,
+            StorageKey::Admin as u32,
+            StorageKey::AuthorizedSigner as u32,
+            StorageKey::SweepNonce as u32,
+            StorageKey::AuthorizedDestination as u32,
+            StorageKey::EphemeralAccountWasmHash as u32,
+            StorageKey::StorageVersion as u32,
+        ];
+
+        let mut sorted = keys;
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            keys.len(),
+            "duplicate StorageKey discriminant detected"
+        );
+    }
+
+    #[test]
+    fn convenience_helpers_return_expected_variants() {
+        assert_eq!(
+            StorageKey::key_initialized(),
+            StorageKey::Initialized
+        );
+        assert_eq!(StorageKey::key_creator(), StorageKey::Creator);
+        assert_eq!(StorageKey::key_storage_version(), StorageKey::StorageVersion);
+    }
+}

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contracttype, Address, Bytes, Vec};
 
-// Represents a payment received by the ephemeral account.
+/// Represents a payment received by the ephemeral account.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Payment {
@@ -8,7 +8,8 @@ pub struct Payment {
     pub amount: i128,
     pub timestamp: u64,
 }
-// The current status of an ephemeral account.
+
+/// The current status of an ephemeral account.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq, Copy)]
 #[repr(u32)]
@@ -48,4 +49,85 @@ pub struct AccountInitResult {
     pub account_address: Address,
     pub success: bool,
     pub error: Option<Bytes>,
+}
+
+/// Payload sent off-chain to authorize a sweep operation.
+///
+/// The SDK serialises this, signs it with the authorised Ed25519 key, and
+/// passes the resulting signature to `execute_sweep()` or `claim()`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SweepPayload {
+    /// Address of the ephemeral account to sweep.
+    pub ephemeral_account: Address,
+    /// Destination wallet that should receive the funds.
+    pub destination: Address,
+    /// Monotonic nonce — must match the on-chain nonce at verification time.
+    pub nonce: u64,
+    /// The network passphrase the signature was created against.
+    pub network_passphrase: Bytes,
+}
+
+/// Snapshot of a single asset balance held by an ephemeral account.
+///
+/// Useful for SDK-level fee estimation and pre-sweep validation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AssetBalance {
+    /// SEP-41 token contract address.
+    pub asset: Address,
+    /// Balance in the token's smallest unit (stroops for native XLM).
+    pub balance: i128,
+}
+
+/// Version metadata stored on-chain to support forward-compatible
+/// storage migrations (see StorageVersion key).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractVersion {
+    /// Major version — breaking storage changes.
+    pub major: u32,
+    /// Minor version — backward-compatible additions.
+    pub minor: u32,
+    /// Patch version — bug fixes only.
+    pub patch: u32,
+}
+
+impl ContractVersion {
+    /// Returns a `u32` packed as `major << 16 | minor << 8 | patch`.
+    pub fn packed(&self) -> u32 {
+        ((self.major & 0xFF) << 16) | ((self.minor & 0xFF) << 8) | (self.patch & 0xFF)
+    }
+
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    pub fn initial() -> Self {
+        Self::new(1, 0, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_version_packed() {
+        let v = ContractVersion::new(2, 3, 4);
+        assert_eq!(v.packed(), (2 << 16) | (3 << 8) | 4);
+    }
+
+    #[test]
+    fn contract_version_initial() {
+        let v = ContractVersion::initial();
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 0);
+        assert_eq!(v.patch, 0);
+        assert_eq!(v.packed(), 1 << 16);
+    }
 }

--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -21,6 +21,10 @@ use authorization::AuthContext;
 use bridgelet_shared::{AccountStatus, Payment};
 pub use errors::Error;
 
+/// Expected network passphrase for this deployment.
+/// Change to `PUBLIC_NETWORK_PASSPHRASE` for mainnet.
+const EXPECTED_PASSPHRASE: &str = bridgelet_shared::passphrase::STANDALONE_PASSPHRASE;
+
 #[contract]
 pub struct SweepController;
 
@@ -48,6 +52,10 @@ impl SweepController {
 
         // Require the creator to authorize this initialization
         creator.require_auth();
+
+        // Enforce deploy-time network passphrase to prevent accidental testnet→mainnet deployment
+        bridgelet_shared::passphrase::require_network(&env, EXPECTED_PASSPHRASE)
+            .map_err(|_| Error::AuthorizationFailed)?;
 
         storage::set_creator(&env, &creator);
 


### PR DESCRIPTION
## Summary

Implements four shared-module improvements for the bridgelet-core workspace:

### #139 - Define storage key constants in shared module
- Created `contracts/shared/storage_keys.rs` with a canonical `StorageKey` enum covering all Soroban storage keys across both contracts.
- Prevents typos in key names and makes namespace auditing trivial.
- Includes a distinct-discriminant test to catch accidental key aliasing.

### #138 - Centralise common error variants in shared/errors.rs
- Created `contracts/shared/errors.rs` with `SharedError` enum for error variants common to both contracts: `NotInitialized`, `AlreadyInitialized`, `Unauthorized`, `Expired`, `NotExpired`, `Overflow`, `InvalidAmount`.
- Includes collision-avoidance tests against each contract error codes.

### #137 - Expand shared/types.rs with all cross-contract types
- Added `SweepPayload` (off-chain sweep authorization context), `AssetBalance` (per-asset balance snapshot), and `ContractVersion` (packed semver for storage migration versioning).
- Includes unit tests for packed representation.

### #136 - Enforce network passphrase check at deploy time
- Created `contracts/shared/passphrase.rs` with network passphrase validation utility.
- Both `EphemeralAccount::initialize()` and `SweepController::initialize()` now enforce the expected network passphrase at deploy time, preventing accidental testnet to mainnet or standalone to testnet deployments.

Closes #139
Closes #138
Closes #137
Closes #136