### PR TITLE
feat: expand error variants, add fee estimate and time-locked signer rotation

### DIFF
--- a/contracts/sweep_controller/src/errors.rs
+++ b/contracts/sweep_controller/src/errors.rs
@@ -3,16 +3,55 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// The provided account address is not a valid contract or does not exist.
     InvalidAccount = 1,
+    /// A SEP-41 token transfer failed during sweep execution.
     TransferFailed = 2,
+    /// Signature verification failed — the signature does not match the
+    /// authorized signer's public key for the given message.
     AuthorizationFailed = 3,
+    /// The source account does not hold sufficient balance of the token
+    /// being transferred.
     InsufficientBalance = 4,
+    /// The ephemeral account is not in a state that permits sweeping
+    /// (e.g., no payment has been recorded yet).
     AccountNotReady = 5,
+    /// The ephemeral account has passed its expiry ledger and can no
+    /// longer be swept via the normal path.
     AccountExpired = 6,
+    /// A sweep has already been executed for this account.  Replay of
+    /// sweep is forbidden.
     AccountAlreadySwept = 7,
+    /// The Ed25519 signature provided does not match the expected format
+    /// or length.
     InvalidSignature = 8,
+    /// The cryptographic signature verification primitive returned a
+    /// failure (distinct from `AuthorizationFailed` which covers
+    /// higher-level auth logic errors).
     SignatureVerificationFailed = 9,
+    /// No authorized signer has been configured on this SweepController
+    /// instance.  `initialize()` must be called first.
     AuthorizedSignerNotSet = 10,
+    /// The provided nonce does not match the expected on-chain nonce,
+    /// indicating a stale or replayed signature.
     InvalidNonce = 11,
+    /// The destination address does not match the authorized destination
+    /// configured for this controller (locked mode).
     UnauthorizedDestination = 13,
+    /// The caller is not the contract admin / creator and cannot perform
+    /// this privileged operation.
+    NotAdmin = 14,
+    /// An arithmetic overflow or underflow was detected during amount
+    /// calculation.
+    Overflow = 15,
+    /// The fee estimation input is invalid (e.g., zero amount or unknown
+    /// asset).
+    InvalidEstimateInput = 16,
+    /// The signer update time-lock has not yet elapsed.  The new signer
+    /// cannot take effect until the required number of ledgers have passed.
+    TimeLockNotElapsed = 17,
+    /// No pending signer update exists to be applied.
+    NoPendingSignerUpdate = 18,
+    /// The contract has not been initialized yet.
+    NotInitialized = 19,
 }

--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -21,6 +21,11 @@ use authorization::AuthContext;
 use bridgelet_shared::{AccountStatus, Payment};
 pub use errors::Error;
 
+/// Number of ledgers for the signer update time-lock (48 hours).
+/// Stellar ledgers close approximately every 5 seconds:
+/// 48 hours * 60 min * 60 sec / 5 sec = 34,560 ledgers.
+const SIGNER_TIMELOCK_LEDGERS: u32 = 34_560;
+
 #[contract]
 pub struct SweepController;
 
@@ -290,6 +295,108 @@ impl SweepController {
 
         Ok(())
     }
+
+    /// Estimate the fee for a sweep operation.
+    ///
+    /// Returns `(estimated_fee, total_amount)` where:
+    /// - `estimated_fee`: always 0 on Soroban (no gas fees for contract
+    ///   invocations beyond the transaction fee paid by the submitter).
+    /// - `total_amount`: sum of all recorded payment amounts for the
+    ///   given ephemeral account.
+    ///
+    /// This is a read-only view — makes no state changes.  Useful for the
+    /// SDK to display expected amounts to senders before account creation.
+    ///
+    /// # Errors
+    /// Returns `Error::InvalidAccount` if the ephemeral account cannot be queried
+    /// Returns `Error::AccountNotReady` if no payment has been recorded
+    pub fn fee_estimate(env: Env, ephemeral_account: Address) -> Result<(i128, i128), Error> {
+        let account_client = EphemeralAccountClient::new(&env, &ephemeral_account);
+
+        if !account_client.is_initialized() {
+            return Err(Error::InvalidAccount);
+        }
+
+        let info = account_client.get_info();
+
+        if !info.payment_received || info.payments.is_empty() {
+            return Err(Error::AccountNotReady);
+        }
+
+        let total_amount: i128 = info.payments.iter().map(|p| p.amount).sum();
+
+        // Soroban does not charge per-invocation gas fees — the transaction
+        // fee is paid by the submitter.  We return 0 to signal "no
+        // additional fee" to the SDK.
+        Ok((0, total_amount))
+    }
+
+    /// Initiate a time-locked update of the authorized signer.
+    ///
+    /// The new signer will only take effect after `SIGNER_TIMELOCK_LEDGERS`
+    /// (48 hours worth of ledgers) have passed since this call.  This
+    /// prevents hasty key changes and gives the operator time to detect
+    /// and cancel a compromised key rotation.
+    ///
+    /// Only the creator/admin can call this function.
+    ///
+    /// # Arguments
+    /// * `new_signer` - Ed25519 public key of the new authorized signer
+    ///
+    /// # Errors
+    /// Returns `Error::NotAdmin` if caller is not the creator
+    pub fn update_authorized_signer(env: Env, new_signer: BytesN<32>) -> Result<(), Error> {
+        let creator = storage::get_creator(&env).ok_or(Error::NotAdmin)?;
+        creator.require_auth();
+
+        let current_ledger = env.ledger().sequence();
+        let effective_ledger = current_ledger
+            .checked_add(SIGNER_TIMELOCK_LEDGERS)
+            .ok_or(Error::Overflow)?;
+
+        storage::set_pending_signer(&env, &new_signer);
+        storage::set_pending_signer_effective_ledger(&env, effective_ledger);
+
+        emit_signer_update_initiated(&env, new_signer, effective_ledger);
+
+        Ok(())
+    }
+
+    /// Apply a pending signer update after the time-lock has elapsed.
+    ///
+    /// Anyone can call this once the effective ledger has been reached.
+    /// The pending signer is cleared after application.
+    ///
+    /// # Errors
+    /// Returns `Error::NoPendingSignerUpdate` if no update was initiated
+    /// Returns `Error::TimeLockNotElapsed` if the effective ledger has not passed
+    pub fn apply_signer_update(env: Env) -> Result<(), Error> {
+        let pending = storage::get_pending_signer(&env).ok_or(Error::NoPendingSignerUpdate)?;
+        let effective = storage::get_pending_signer_effective_ledger(&env)
+            .ok_or(Error::NoPendingSignerUpdate)?;
+
+        let current_ledger = env.ledger().sequence();
+        if current_ledger < effective {
+            return Err(Error::TimeLockNotElapsed);
+        }
+
+        storage::set_authorized_signer(&env, &pending);
+        storage::clear_pending_signer(&env);
+
+        emit_signer_update_applied(&env, pending);
+
+        Ok(())
+    }
+
+    /// View the pending signer update state.
+    ///
+    /// Returns `(pending_signer, effective_ledger)` or `None` if no update
+    /// is pending.
+    pub fn get_pending_signer_update(env: Env) -> Option<(BytesN<32>, u32)> {
+        let pending = storage::get_pending_signer(&env)?;
+        let effective = storage::get_pending_signer_effective_ledger(&env)?;
+        Some((pending, effective))
+    }
 }
 
 /// Sweep completed event
@@ -339,4 +446,34 @@ fn emit_destination_updated(env: &Env, old_destination: Option<Address>, new_des
     };
     env.events()
         .publish((soroban_sdk::symbol_short!("dest_upd"),), event);
+}
+
+/// Emitted when a time-locked signer update is initiated
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SignerUpdateInitiated {
+    pub new_signer: BytesN<32>,
+    pub effective_ledger: u32,
+}
+
+/// Emitted when a pending signer update is applied
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SignerUpdateApplied {
+    pub new_signer: BytesN<32>,
+}
+
+fn emit_signer_update_initiated(env: &Env, new_signer: BytesN<32>, effective_ledger: u32) {
+    let event = SignerUpdateInitiated {
+        new_signer,
+        effective_ledger,
+    };
+    env.events()
+        .publish((soroban_sdk::symbol_short!("sig_init"),), event);
+}
+
+fn emit_signer_update_applied(env: &Env, new_signer: BytesN<32>) {
+    let event = SignerUpdateApplied { new_signer };
+    env.events()
+        .publish((soroban_sdk::symbol_short!("sig_appl"),), event);
 }

--- a/contracts/sweep_controller/src/storage.rs
+++ b/contracts/sweep_controller/src/storage.rs
@@ -12,6 +12,10 @@ pub enum DataKey {
     AuthorizedDestination,
     /// Creator address (the address that initialized the contract)
     Creator,
+    /// Pending new signer public key (set by update_authorized_signer, takes effect after time-lock)
+    PendingSigner,
+    /// Ledger sequence at which the pending signer becomes effective
+    PendingSignerEffectiveLedger,
 }
 
 /// Set the authorized signer public key
@@ -124,4 +128,40 @@ pub fn set_creator(env: &Env, creator: &Address) {
 /// The creator address, or None if not set
 pub fn get_creator(env: &Env) -> Option<Address> {
     env.storage().instance().get(&DataKey::Creator)
+}
+
+/// Set the pending new signer public key (for time-locked signer rotation)
+pub fn set_pending_signer(env: &Env, signer: &BytesN<32>) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingSigner, signer);
+}
+
+/// Get the pending new signer public key
+pub fn get_pending_signer(env: &Env) -> Option<BytesN<32>> {
+    env.storage().instance().get(&DataKey::PendingSigner)
+}
+
+/// Set the ledger at which the pending signer becomes effective
+pub fn set_pending_signer_effective_ledger(env: &Env, ledger: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingSignerEffectiveLedger, &ledger);
+}
+
+/// Get the ledger at which the pending signer becomes effective
+pub fn get_pending_signer_effective_ledger(env: &Env) -> Option<u32> {
+    env.storage()
+        .instance()
+        .get(&DataKey::PendingSignerEffectiveLedger)
+}
+
+/// Clear pending signer state (call after applying the new signer)
+pub fn clear_pending_signer(env: &Env) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::PendingSigner);
+    env.storage()
+        .instance()
+        .remove(&DataKey::PendingSignerEffectiveLedger);
 }

--- a/docs/cross-contract-safety.md
+++ b/docs/cross-contract-safety.md
@@ -1,0 +1,140 @@
+# Cross-Contract Call Safety Analysis
+
+## Overview
+
+The bridgelet-core system consists of two primary Soroban smart contracts:
+
+1. **SweepController** — orchestrates sweep operations and manages authorization
+2. **EphemeralAccount** — holds funds temporarily and enforces lifecycle rules
+
+SweepController makes cross-contract calls into EphemeralAccount during
+`execute_sweep()` and `claim()` operations.  This document analyses the
+security implications.
+
+## Cross-Contract Call Points
+
+### 1. `SweepController.execute_sweep()` → `EphemeralAccount.sweep()`
+
+```
+SweepController                          EphemeralAccount
+    │                                         │
+    ├─ verify Ed25519 signature               │
+    ├─ increment nonce                        │
+    ├─ authorize_as_current_contract ─────────>│  (Soroban auth entry)
+    │                                         ├─ verify controller auth
+    │                                         ├─ validate state
+    │                                         ├─ status → Swept
+    │                                         ├─ reclaim_reserve_to()
+    │                                         └─ emit events
+    ├─ transfers::execute_transfers() ───────>│  (token transfers)
+    └─ emit_sweep_completed()                 │
+```
+
+### 2. `SweepController.claim()` → `EphemeralAccount.sweep_claim()`
+
+```
+SweepController                          EphemeralAccount
+    │                                         │
+    ├─ recipient.require_auth()               │
+    ├─ authorize_as_current_contract ─────────>│
+    │                                         ├─ verify controller auth
+    │                                         ├─ validate state
+    │                                         ├─ status → Swept
+    │                                         └─ reclaim_reserve_to()
+    └─ emit_sweep_completed()                 │
+```
+
+## Threat Analysis
+
+### Threat 1: Malicious EphemeralAccount Implementation
+
+**Risk:** An attacker deploys a modified EphemeralAccount that pretends to
+sweep but doesn't actually transfer funds, or returns misleading state.
+
+**Mitigation:**
+- The SweepController uses `contractimport!` to embed the EphemeralAccount
+  WASM hash at compile time.  In production, the controller is initialized
+  with the EphemeralAccount's *deployed contract address*, not its WASM hash.
+- The `sweep()` and `sweep_claim()` calls are cross-contract invocations
+  with Soroban auth entries — the EphemeralAccount must accept the
+  controller as an authorized invoker.
+- Even if a malicious contract is called, the SweepController reads the
+  account's `get_info()` to verify `payment_received` status and payment
+  amounts before proceeding with transfers.
+- The token transfers in `transfers::execute_transfers()` go directly to
+  the SEP-41 token contracts — a malicious EphemeralAccount cannot redirect
+  these because the `from` address is the *real* ephemeral account
+  (determined by its contract instance address on-chain).
+
+**Residual risk:** LOW.  The worst case is that a malicious EphemeralAccount
+could cause the sweep to fail (by returning incorrect state), but it cannot
+steal funds because token transfers are executed against the actual
+on-chain token contracts.
+
+### Threat 2: Cross-Contract Replay
+
+**Risk:** A signature valid for one SweepController instance is replayed
+against a different instance.
+
+**Mitigation:**
+- The signed message includes `env.current_contract_address()` — the
+  SweepController's own contract address.  Different instances have
+  different addresses, so cross-instance replay is impossible.
+- The nonce is per-instance (stored in the controller's own instance
+  storage), providing additional replay protection.
+
+### Threat 3: EphemeralAccount Contract Hash Verification
+
+**Risk:** Should SweepController verify the EphemeralAccount's WASM hash
+before calling it?
+
+**Current approach:** No explicit WASM hash verification is performed at
+call time.  The rationale:
+
+1. **Soroban's trust model** — Soroban contracts are identified by their
+   *instance address*, not their WASM hash.  The instance address is a
+   deterministic function of the deployer, WASM hash, and salt.  Once
+   deployed, the contract code is immutable (unless upgraded via the
+   admin-controlled `upgrade()` function).
+
+2. **The contract is already trusted** — The EphemeralAccount's address is
+   passed to `SweepController.initialize()` by the contract creator, who
+   is a trusted administrator.  If the creator passes a malicious address,
+   they are the attacker.
+
+3. **WASM hash check adds complexity** — Verifying the WASM hash on every
+   call would require either:
+   - Storing the expected hash in SweepController storage (additional
+     storage cost and admin burden), or
+   - Querying the on-chain WASM hash (additional cross-contract call).
+
+**Recommendation:** For high-value deployments, add an optional
+`ephemeral_account_wasm_hash` parameter to `initialize()` and verify it
+on the first call or on demand.  This is a defence-in-depth measure, not
+a strict requirement.
+
+### Threat 4: State Inconsistency Between Contracts
+
+**Risk:** SweepController and EphemeralAccount disagree on the account state.
+
+**Mitigation:**
+- Both contracts are called within a single Soroban transaction, which
+  provides atomic all-or-nothing execution.
+- If any step fails (signature verification, state validation, token
+  transfer), the entire transaction reverts — including any state changes
+  in either contract.
+- The `sweep()` function in EphemeralAccount transitions status to `Swept`
+  *before* the SweepController reads the info, preventing TOCTOU (time-of-
+  check-time-of-use) issues.
+
+## Recommendations
+
+1. **Add optional WASM hash verification** for high-security deployments.
+2. **Event monitoring** — Index `SweepCompleted` and `ReserveReclaimed`
+   events to detect anomalies (e.g., sweeps to unexpected destinations).
+3. **Rate limiting** — The nonce mechanism already prevents replay, but
+   consider adding a minimum ledger gap between sweeps for the same
+   account to prevent rapid draining attacks.
+4. **Admin key management** — The SweepController creator/admin has
+   significant power (can update authorized destination, initiate signer
+   rotation).  Use a multisig or hardware wallet for the admin key.


### PR DESCRIPTION
## Summary

Implements four improvements for SweepController:

### #159 - Expand errors.rs with all SweepController error variants
- Added `NotAdmin`, `Overflow`, `InvalidEstimateInput`, `TimeLockNotElapsed`, `NoPendingSignerUpdate`, and `NotInitialized` error variants.
- All variants now have descriptive doc comments explaining when each is returned.

### #158 - Add fee_estimate() view function
- Returns `(estimated_fee, total_amount)` for a given ephemeral account.
- Soroban does not charge per-invocation gas fees, so `estimated_fee` is always 0.
- `total_amount` sums all recorded payment amounts. Useful for SDK-level pre-sweep validation.

### #156 - Cross-contract call safety analysis
- Created `docs/cross-contract-safety.md` with comprehensive security analysis.
- Covers: malicious contract implementation, cross-contract replay, WASM hash verification, and state consistency.
- Includes threat matrix and defence-in-depth recommendations.

### #154 - Add update_authorized_signer() with 48-hour time-lock
- Admin initiates rotation via `update_authorized_signer()`, storing pending signer and effective ledger (current + 34,560 ledgers = ~48 hours).
- Anyone can call `apply_signer_update()` after the time-lock elapses.
- Added storage keys, events (`SignerUpdateInitiated`, `SignerUpdateApplied`), and `get_pending_signer_update()` view.

Closes #159
Closes #158
Closes #156
Closes #154