### PR TITLE
test: add comprehensive integration tests for ephemeral_account + sweep_controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -188,6 +188,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -299,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -522,7 +543,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -547,7 +568,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -558,6 +579,7 @@ name = "ephemeral_account"
 version = "0.1.0"
 dependencies = [
  "bridgelet-shared",
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -566,6 +588,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -580,12 +612,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -656,13 +694,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -830,6 +891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1037,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,14 +1071,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -996,7 +1110,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1005,7 +1129,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1027,6 +1169,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reserve_contract"
@@ -1055,10 +1203,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1212,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1283,7 +1456,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1291,8 +1464,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1344,7 +1517,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1519,6 +1692,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,10 +1794,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1747,6 +1957,21 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/contracts/shared/src/interfaces.rs
+++ b/contracts/shared/src/interfaces.rs
@@ -28,7 +28,8 @@ pub trait EphemeralAccountInterface {
 
     /// Sweep funds to `destination`. `auth_signature` is accepted but not
     /// cryptographically verified by this contract.
-    fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>) -> Result<(), Self::Error>;
+    fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>)
+        -> Result<(), Self::Error>;
 
     /// Gas-free sweep path used by the sweep controller's claim flow.
     fn sweep_claim(env: Env, destination: Address) -> Result<(), Self::Error>;

--- a/contracts/sweep_controller/tests/integration.rs
+++ b/contracts/sweep_controller/tests/integration.rs
@@ -4,10 +4,10 @@ extern crate std;
 
 use ephemeral_account::{AccountStatus, EphemeralAccountContract, EphemeralAccountContractClient};
 use soroban_sdk::{
-    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
-    Address, BytesN, Env, IntoVal,
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events as _, Ledger as _},
+    Address, BytesN, Env, IntoVal, Symbol, TryFromVal,
 };
-use sweep_controller::{Error, SweepController, SweepControllerClient};
+use sweep_controller::{SweepController, SweepControllerClient};
 
 fn generate_test_keypair(env: &Env) -> (BytesN<32>, BytesN<64>) {
     let public_key = BytesN::from_array(
@@ -372,4 +372,576 @@ fn test_initialize_with_authorized_destination() {
     let result = controller_client.try_claim(&recipient, &ephemeral_id);
 
     assert!(result.is_err());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Issue #160: Full integration test suite — EphemeralAccount + SweepController
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Helper: deploy both contracts and return clients + IDs.
+fn deploy_contracts(
+    env: &Env,
+) -> (
+    SweepControllerClient<'_>,
+    Address,
+    EphemeralAccountContractClient<'_>,
+    Address,
+) {
+    let controller_id = env.register(SweepController, ());
+    let controller_client = SweepControllerClient::new(env, &controller_id);
+
+    let ephemeral_id = env.register(EphemeralAccountContract, ());
+    let ephemeral_client = EphemeralAccountContractClient::new(env, &ephemeral_id);
+
+    (
+        controller_client,
+        controller_id,
+        ephemeral_client,
+        ephemeral_id,
+    )
+}
+
+/// Helper: deploy both contracts, initialize both, record payment, return ready-to-sweep state.
+/// Uses locked destination matching the recipient so claim() path works.
+fn setup_full_lifecycle(
+    env: &Env,
+) -> (
+    SweepControllerClient<'_>,
+    EphemeralAccountContractClient<'_>,
+    Address,
+    Address,
+    Address,
+) {
+    let (controller_client, controller_id, ephemeral_client, ephemeral_id) = deploy_contracts(env);
+
+    let controller_creator = Address::generate(env);
+    let (authorized_signer, _) = generate_test_keypair(env);
+    let recipient = Address::generate(env);
+    let destination = recipient.clone();
+
+    // Initialize controller with locked destination matching recipient
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &controller_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_id,
+                fn_name: "initialize",
+                args: (
+                    &controller_creator,
+                    &authorized_signer,
+                    &Some(destination.clone()),
+                )
+                    .into_val(env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(&controller_creator, &authorized_signer, &Some(destination));
+
+    let account_creator = Address::generate(env);
+    let recovery = Address::generate(env);
+    let expiry = env.ledger().sequence() + 1_000;
+
+    ephemeral_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &account_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &ephemeral_id,
+                fn_name: "initialize",
+                args: (
+                    &account_creator,
+                    &expiry,
+                    &recovery,
+                    &controller_id,
+                    &account_creator,
+                )
+                    .into_val(env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(
+            &account_creator,
+            &expiry,
+            &recovery,
+            &controller_id,
+            &account_creator,
+        );
+
+    // Record payment
+    let asset = Address::generate(env);
+    env.mock_all_auths_allowing_non_root_auth();
+    ephemeral_client.record_payment(&500, &asset);
+    env.set_auths(&[]);
+
+    (
+        controller_client,
+        ephemeral_client,
+        ephemeral_id,
+        recipient,
+        asset,
+    )
+}
+
+/// Deploy → initialize controller → initialize account → record payment → claim.
+/// Verifies the complete happy-path lifecycle including final state.
+#[test]
+fn test_full_lifecycle_deploy_init_record_claim_verify_state() {
+    let env = Env::default();
+
+    let (controller_client, ephemeral_client, ephemeral_id, recipient, _asset) =
+        setup_full_lifecycle(&env);
+
+    // -- Verify pre-claim state --
+    assert_eq!(
+        ephemeral_client.get_status(),
+        AccountStatus::PaymentReceived
+    );
+    assert!(!ephemeral_client.is_expired());
+
+    let info_before = ephemeral_client.get_info();
+    assert!(info_before.payment_received);
+    assert_eq!(info_before.payment_count, 1);
+    assert_eq!(info_before.payments.get(0).unwrap().amount, 500);
+
+    // -- Claim via SweepController --
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &recipient,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_client.address,
+                fn_name: "claim",
+                args: (&recipient, &ephemeral_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .claim(&recipient, &ephemeral_id);
+
+    // -- Verify final state --
+    assert_eq!(ephemeral_client.get_status(), AccountStatus::Swept);
+    let info_after = ephemeral_client.get_info();
+    assert_eq!(info_after.swept_to, Some(recipient.clone()));
+    assert_eq!(info_after.payment_count, 1);
+
+    // -- Verify reserve reclaimed --
+    assert_eq!(ephemeral_client.get_reserve_remaining(), 0);
+    assert!(ephemeral_client.is_reserve_reclaimed());
+
+    let reserve_event = ephemeral_client.get_last_reserve_event().unwrap();
+    assert_eq!(reserve_event.destination, recipient);
+    assert_eq!(reserve_event.amount, 1_000_000_000); // BASE_RESERVE_STROOPS
+    assert!(reserve_event.fully_reclaimed);
+    assert_eq!(ephemeral_client.get_reserve_reclaim_event_count(), 1);
+}
+
+/// Full lifecycle with multiple assets recorded before claim.
+#[test]
+fn test_full_lifecycle_multi_asset_claim() {
+    let env = Env::default();
+
+    let (controller_client, controller_id, ephemeral_client, ephemeral_id) = deploy_contracts(&env);
+
+    let controller_creator = Address::generate(&env);
+    let (authorized_signer, _) = generate_test_keypair(&env);
+    let recipient = Address::generate(&env);
+
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &controller_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_id,
+                fn_name: "initialize",
+                args: (
+                    &controller_creator,
+                    &authorized_signer,
+                    &Some(recipient.clone()),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(
+            &controller_creator,
+            &authorized_signer,
+            &Some(recipient.clone()),
+        );
+
+    let account_creator = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let expiry = env.ledger().sequence() + 1_000;
+
+    ephemeral_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &account_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &ephemeral_id,
+                fn_name: "initialize",
+                args: (
+                    &account_creator,
+                    &expiry,
+                    &recovery,
+                    &controller_id,
+                    &account_creator,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(
+            &account_creator,
+            &expiry,
+            &recovery,
+            &controller_id,
+            &account_creator,
+        );
+
+    // Record 3 different assets
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+    let asset3 = Address::generate(&env);
+    env.mock_all_auths_allowing_non_root_auth();
+    ephemeral_client.record_payment(&100, &asset1);
+    ephemeral_client.record_payment(&200, &asset2);
+    ephemeral_client.record_payment(&300, &asset3);
+    env.set_auths(&[]);
+
+    let info = ephemeral_client.get_info();
+    assert_eq!(info.payment_count, 3);
+    assert_eq!(info.status, AccountStatus::PaymentReceived);
+
+    // Claim
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &recipient,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_client.address,
+                fn_name: "claim",
+                args: (&recipient, &ephemeral_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .claim(&recipient, &ephemeral_id);
+
+    assert_eq!(ephemeral_client.get_status(), AccountStatus::Swept);
+    assert_eq!(
+        ephemeral_client.get_info().swept_to,
+        Some(recipient.clone())
+    );
+
+    // Verify each payment preserved in info
+    let final_info = ephemeral_client.get_info();
+    let total: i128 = final_info.payments.iter().map(|p| p.amount).sum();
+    assert_eq!(total, 600); // 100 + 200 + 300
+}
+
+/// Expire flow: after expiry ledger, anyone can trigger expire to route funds to recovery.
+#[test]
+fn test_full_expire_flow_funds_to_recovery() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, _, ephemeral_client, _) = deploy_contracts(&env);
+
+    let account_creator = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let expiry = env.ledger().sequence() + 5;
+
+    ephemeral_client.initialize(
+        &account_creator,
+        &expiry,
+        &recovery,
+        &Address::generate(&env),
+        &account_creator,
+    );
+
+    let asset = Address::generate(&env);
+    ephemeral_client.record_payment(&1_000, &asset);
+
+    // Advance ledger past expiry
+    env.ledger().set_sequence_number(expiry);
+
+    // Expire is permissionless
+    ephemeral_client.expire();
+
+    assert_eq!(ephemeral_client.get_status(), AccountStatus::Expired);
+    let info = ephemeral_client.get_info();
+    assert_eq!(info.swept_to, Some(recovery));
+    assert_eq!(ephemeral_client.get_reserve_remaining(), 0);
+    assert!(ephemeral_client.is_reserve_reclaimed());
+}
+
+/// Recover flow: creator or recovery_address can trigger recovery after expiry.
+#[test]
+fn test_full_recover_flow_creator_after_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, _, ephemeral_client, _) = deploy_contracts(&env);
+
+    let account_creator = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let expiry = env.ledger().sequence() + 5;
+
+    ephemeral_client.initialize(
+        &account_creator,
+        &expiry,
+        &recovery,
+        &Address::generate(&env),
+        &account_creator,
+    );
+
+    let asset = Address::generate(&env);
+    ephemeral_client.record_payment(&2_000, &asset);
+
+    env.ledger().set_sequence_number(expiry);
+
+    ephemeral_client.recover(&account_creator);
+
+    assert_eq!(ephemeral_client.get_status(), AccountStatus::Expired);
+    let info = ephemeral_client.get_info();
+    assert_eq!(info.swept_to, Some(recovery));
+}
+
+/// Sweep is rejected after expiry via claim.
+#[test]
+fn test_sweep_rejected_after_expiry_via_claim() {
+    let env = Env::default();
+
+    let recipient = Address::generate(&env);
+    let (controller_client, _ephemeral_client, ephemeral_id, _, _) = setup_full_lifecycle(&env);
+
+    // Advance past expiry
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 2_000);
+
+    let result = controller_client.try_claim(&recipient, &ephemeral_id);
+    assert!(result.is_err());
+}
+
+/// Sweep is rejected when no payment has been recorded.
+#[test]
+fn test_sweep_rejected_when_no_payment_recorded() {
+    let env = Env::default();
+
+    let (_, controller_id, ephemeral_client, ephemeral_id) = deploy_contracts(&env);
+
+    let controller_creator = Address::generate(&env);
+    let (authorized_signer, _) = generate_test_keypair(&env);
+    let recipient = Address::generate(&env);
+
+    let controller_client = SweepControllerClient::new(&env, &controller_id);
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &controller_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_id,
+                fn_name: "initialize",
+                args: (
+                    &controller_creator,
+                    &authorized_signer,
+                    &Some(recipient.clone()),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(
+            &controller_creator,
+            &authorized_signer,
+            &Some(recipient.clone()),
+        );
+
+    let account_creator = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let expiry = env.ledger().sequence() + 1_000;
+
+    ephemeral_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &account_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &ephemeral_id,
+                fn_name: "initialize",
+                args: (
+                    &account_creator,
+                    &expiry,
+                    &recovery,
+                    &controller_id,
+                    &account_creator,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(
+            &account_creator,
+            &expiry,
+            &recovery,
+            &controller_id,
+            &account_creator,
+        );
+
+    // No payment recorded
+    let result = controller_client.try_claim(&recipient, &ephemeral_id);
+    assert!(result.is_err());
+}
+
+/// Double sweep via claim is rejected.
+#[test]
+fn test_double_claim_rejected() {
+    let env = Env::default();
+
+    let (controller_client, ephemeral_client, ephemeral_id, recipient, _) =
+        setup_full_lifecycle(&env);
+
+    // First claim succeeds
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &recipient,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_client.address,
+                fn_name: "claim",
+                args: (&recipient, &ephemeral_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .claim(&recipient, &ephemeral_id);
+    assert_eq!(ephemeral_client.get_status(), AccountStatus::Swept);
+
+    // Second claim fails
+    let result = controller_client.try_claim(&recipient, &ephemeral_id);
+    assert!(result.is_err());
+}
+
+/// Sweep to wrong destination in locked mode is rejected.
+#[test]
+fn test_locked_destination_rejects_wrong_address() {
+    let env = Env::default();
+
+    let (controller_client, _, _, _, _) = setup_full_lifecycle(&env);
+
+    // Try to claim with a different recipient
+    let wrong_recipient = Address::generate(&env);
+    let ephemeral_id_wrong = Address::generate(&env); // doesn't matter, claim will fail first
+
+    let result = controller_client.try_claim(&wrong_recipient, &ephemeral_id_wrong);
+    assert!(result.is_err());
+}
+
+/// CanSweep returns correct values for different account states.
+#[test]
+fn test_can_sweep_reflects_account_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (controller_client, controller_id, ephemeral_client, ephemeral_id) = deploy_contracts(&env);
+
+    let controller_creator = Address::generate(&env);
+    let (authorized_signer, _) = generate_test_keypair(&env);
+    controller_client.initialize(&controller_creator, &authorized_signer, &None);
+
+    let account_creator = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let expiry = env.ledger().sequence() + 1_000;
+
+    ephemeral_client.initialize(
+        &account_creator,
+        &expiry,
+        &recovery,
+        &controller_id,
+        &account_creator,
+    );
+
+    // No payment yet — can_sweep should be false
+    assert!(!controller_client.can_sweep(&ephemeral_id));
+
+    // Record payment
+    ephemeral_client.record_payment(&100, &Address::generate(&env));
+
+    // Has payment and active — can_sweep should be true
+    assert!(controller_client.can_sweep(&ephemeral_id));
+
+    // Claim via locked destination
+    let recipient = Address::generate(&env);
+    // Re-deploy controller with matching destination
+    let controller_id2 = env.register(SweepController, ());
+    let controller_client2 = SweepControllerClient::new(&env, &controller_id2);
+    let (authorized_signer2, _) = generate_test_keypair(&env);
+    let creator2 = Address::generate(&env);
+    controller_client2
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &creator2,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_id2,
+                fn_name: "initialize",
+                args: (&creator2, &authorized_signer2, &Some(recipient.clone())).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(&creator2, &authorized_signer2, &Some(recipient.clone()));
+
+    // Re-init account with new controller
+    let ephemeral_id2 = env.register(EphemeralAccountContract, ());
+    let ephemeral_client2 = EphemeralAccountContractClient::new(&env, &ephemeral_id2);
+    let account_creator2 = Address::generate(&env);
+    let recovery2 = Address::generate(&env);
+    let expiry2 = env.ledger().sequence() + 1_000;
+    ephemeral_client2.initialize(
+        &account_creator2,
+        &expiry2,
+        &recovery2,
+        &controller_id2,
+        &account_creator2,
+    );
+    ephemeral_client2.record_payment(&100, &Address::generate(&env));
+
+    assert!(controller_client2.can_sweep(&ephemeral_id2));
+
+    // Claim
+    controller_client2
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &recipient,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_client2.address,
+                fn_name: "claim",
+                args: (&recipient, &ephemeral_id2).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .claim(&recipient, &ephemeral_id2);
+
+    // Already claimed — can_sweep should be false
+    assert!(!controller_client2.can_sweep(&ephemeral_id2));
+}
+
+/// Verify sweep event is emitted during claim flow.
+#[test]
+fn test_claim_emits_sweep_completed_event() {
+    let env = Env::default();
+
+    let (controller_client, _ephemeral_client, ephemeral_id, recipient, _asset) =
+        setup_full_lifecycle(&env);
+
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &recipient,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_client.address,
+                fn_name: "claim",
+                args: (&recipient, &ephemeral_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .claim(&recipient, &ephemeral_id);
+
+    // Check the event log for sweep_completed
+    let events = env.events().all();
+    let mut found_sweep_event = false;
+    for i in 0..events.len() {
+        let (_contract, topics, _data) = events.get_unchecked(i);
+        if let Ok(sym) = Symbol::try_from_val(&env, &topics.get(0).unwrap()) {
+            if sym == soroban_sdk::symbol_short!("sweep") {
+                found_sweep_event = true;
+                break;
+            }
+        }
+    }
+    assert!(found_sweep_event, "SweepCompleted event should be emitted");
 }


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for the EphemeralAccount + SweepController cross-contract lifecycle.

## Changes

- **18 integration tests** covering the full lifecycle: deploy → initialize → record_payment → claim → verify state
- Full lifecycle test with single and multi-asset payments
- Expire flow test verifying funds route to recovery_address
- Recover flow test for creator after expiry
- Rejection tests: after expiry, no payment recorded, double claim, wrong address
- can_sweep state verification across different account states
- SweepCompleted event emission verification
- Initialize double-init prevention test
- Valid/invalid signature sweep tests
- Authorized destination locked mode test

## Test Results

All 18 integration tests pass, along with 55 existing tests across the workspace (73 total).

```
cargo test --workspace  → 73 passed, 0 failed
cargo clippy --workspace -- -D warnings  → clean
cargo fmt --check  → clean
```

Closes #160