### PR TITLE
docs: clarify sweep path separation (execute_sweep vs claim)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -188,6 +188,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -299,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -522,7 +543,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -547,7 +568,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -558,6 +579,7 @@ name = "ephemeral_account"
 version = "0.1.0"
 dependencies = [
  "bridgelet-shared",
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -566,6 +588,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -580,12 +612,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -656,13 +694,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -830,6 +891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1037,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,14 +1071,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -996,7 +1110,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1005,7 +1129,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1027,6 +1169,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reserve_contract"
@@ -1055,10 +1203,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1212,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1283,7 +1456,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1291,8 +1464,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1344,7 +1517,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1519,6 +1692,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,10 +1794,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1747,6 +1957,21 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -127,16 +127,36 @@ impl EphemeralAccountContract {
         Ok(())
     }
 
-    /// Execute sweep to destination wallet
-    /// Transfers all funds from all assets to the specified destination atomically
+    /// Execute sweep to destination wallet via Ed25519 signature path.
+    ///
+    /// This is the **off-chain signer** sweep path: the caller passes an
+    /// `auth_signature` that was produced off-chain by the `authorized_signer`.
+    /// Authorization is verified against the stored Ed25519 public key.
+    ///
+    /// **Do not call directly** — always route through
+    /// `SweepController::execute_sweep`, which handles signature verification,
+    /// nonce management, and token transfers.
     ///
     /// # Arguments
     /// * `destination` - Recipient wallet address
-    /// * `auth_signature` - Authorization signature from off-chain system
+    /// * `auth_signature` - Ed25519 signature from the authorized off-chain signer
     ///
     /// # Errors
-    /// Returns Error::Unauthorized if authorization fails
-    /// Returns Error::AlreadySwept if sweep already executed
+    /// * `Error::NotInitialized` — contract not yet initialized
+    /// * `Error::AlreadySwept` — account already swept
+    /// * `Error::NoPaymentReceived` — no payment recorded yet
+    /// * `Error::AccountExpired` — past expiry ledger
+    /// * `Error::Unauthorized` — caller is not the authorized controller
+    ///
+    /// # Authorization Flow
+    /// 1. Off-chain: signer signs `hash(destination + nonce + contract_id)`
+    /// 2. Caller invokes `SweepController.execute_sweep(destination, signature)`
+    /// 3. `SweepController` verifies the Ed25519 signature and increments nonce
+    /// 4. `SweepController` calls this function via `authorize_ephemeral_sweep`
+    /// 5. This function validates state, transitions to `Swept`, and reclaims reserve
+    ///
+    /// See also: [`sweep_claim`] for the Soroban-auth claim path used by
+    /// `SweepController::claim`.
     pub fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>) -> Result<(), Error> {
         // Check initialized
         if !storage::is_initialized(&env) {
@@ -188,17 +208,35 @@ impl EphemeralAccountContract {
         Ok(())
     }
 
-    /// Sweep initiated by a direct claim — no off-chain signature required.
-    /// Authorization is enforced entirely by requiring the sweep controller
-    /// as the invoker. Used by SweepController.claim() where the recipient
-    /// has already proven ownership via Soroban auth on the outer transaction.
+    /// Sweep initiated by a direct claim — **no off-chain signature required**.
+    ///
+    /// This is the **Soroban-auth claim** path: authorization is enforced
+    /// entirely by requiring the sweep controller as the invoker via Soroban
+    /// auth. Used by `SweepController::claim()` where the recipient has already
+    /// proven ownership via the Soroban auth entry on the outer transaction.
+    ///
+    /// **Do not call directly** — always route through
+    /// `SweepController::claim`, which handles destination validation, nonce
+    /// management, and event emission.
+    ///
+    /// # Arguments
+    /// * `destination` - Recipient wallet address (must match locked destination if set)
     ///
     /// # Errors
-    /// Returns Error::NotInitialized if contract not initialized
-    /// Returns Error::AlreadySwept if sweep already executed
-    /// Returns Error::NoPaymentReceived if no payment has been recorded
-    /// Returns Error::AccountExpired if past expiry ledger
-    /// Returns Error::Unauthorized if caller is not the authorized controller
+    /// * `Error::NotInitialized` — contract not yet initialized
+    /// * `Error::AlreadySwept` — account already swept
+    /// * `Error::NoPaymentReceived` — no payment recorded yet
+    /// * `Error::AccountExpired` — past expiry ledger
+    /// * `Error::Unauthorized` — caller is not the authorized controller
+    ///
+    /// # Authorization Flow
+    /// 1. Recipient signs a Soroban auth entry for `SweepController::claim`
+    /// 2. Caller (or relayer) invokes `SweepController::claim(recipient, ephemeral_account)`
+    /// 3. `SweepController` validates destination, authorizes as invoker of `sweep_claim`
+    /// 4. This function validates state, transitions to `Swept`, and reclaims reserve
+    ///
+    /// See also: [`sweep`] for the Ed25519 signature path used by
+    /// `SweepController::execute_sweep`.
     pub fn sweep_claim(env: Env, destination: Address) -> Result<(), Error> {
         if !storage::is_initialized(&env) {
             return Err(Error::NotInitialized);

--- a/contracts/shared/src/interfaces.rs
+++ b/contracts/shared/src/interfaces.rs
@@ -28,7 +28,8 @@ pub trait EphemeralAccountInterface {
 
     /// Sweep funds to `destination`. `auth_signature` is accepted but not
     /// cryptographically verified by this contract.
-    fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>) -> Result<(), Self::Error>;
+    fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>)
+        -> Result<(), Self::Error>;
 
     /// Gas-free sweep path used by the sweep controller's claim flow.
     fn sweep_claim(env: Env, destination: Address) -> Result<(), Self::Error>;

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,13 +41,29 @@ Bridgelet Core uses a layered authorization model:
 *   **Scope**: The creator address must authorize the initialization of an `EphemeralAccount`.
 
 ### 2. Sweep Operations
+
+The system supports two sweep paths, both routed through `SweepController`:
+
+#### 2a. `execute_sweep` — Ed25519 Signature Path
 *   **Mechanism**: Ed25519 Signatures + Soroban Auth
 *   **Flow**:
     1.  Off-chain SDK generates a signature covering `hash(destination + nonce + contract_id)`.
-    2.  Caller invokes `SweepController.execute_sweep`.
+    2.  Caller invokes `SweepController::execute_sweep`.
     3.  `SweepController` verifies the Ed25519 signature against the stored `authorized_signer`.
-    4.  `SweepController` calls `EphemeralAccount.sweep`.
-    5.  `EphemeralAccount` validates its internal state and transitions to `Swept`.
+    4.  `SweepController` increments the nonce to prevent replay.
+    5.  `SweepController` authorizes itself as the invoker of `EphemeralAccount::sweep`.
+    6.  `EphemeralAccount::sweep` validates its internal state, transitions to `Swept`, and reclaims the base reserve.
+*   **When to use**: When the off-chain signer is available to produce a signature. Suitable for automated sweep pipelines.
+
+#### 2b. `claim` — Soroban Auth Path
+*   **Mechanism**: Soroban Authorization Entries
+*   **Flow**:
+    1.  The recipient signs a Soroban auth entry for `SweepController::claim`.
+    2.  Caller (or a relayer) invokes `SweepController::claim(recipient, ephemeral_account)`.
+    3.  `SweepController` validates the destination matches the locked destination (if set).
+    4.  `SweepController` authorizes itself as the invoker of `EphemeralAccount::sweep_claim`.
+    5.  `EphemeralAccount::sweep_claim` validates state, transitions to `Swept`, and reclaims the base reserve.
+*   **When to use**: When the recipient is available to sign a Soroban auth entry directly. Suitable for SDK/integration-driven claims where no off-chain signer is needed.
 
 ### 3. Expiration
 *   **Mechanism**: Public (Permissionless)
@@ -70,8 +86,7 @@ The system employs the Checks-Effects-Interactions pattern and leverages Soroban
 ## Known Limitations and Assumptions
 
 ### Critical Implementation Gaps (Current Version)
-1.  **EphemeralAccount Signature Verification**: The `verify_sweep_authorization` function in `EphemeralAccount` is currently a placeholder ("TODO"). **Do not rely on `EphemeralAccount::sweep` directly for security.** Always route sweeps through `SweepController`, which implements proper Ed25519 verification.
-2.  **Token Transfers**: The actual logic to move tokens (calling `token.transfer`) is currently **commented out** or not fully integrated in `SweepController`. The contracts currently manage *state* and *authorization* but do not yet move funds.
+1.  **EphemeralAccount Signature Verification**: The `verify_sweep_authorization` function in `EphemeralAccount` is currently a placeholder. It only checks that the caller is the authorized controller — it does **not** verify the Ed25519 signature bytes. **Do not rely on `EphemeralAccount::sweep` directly for security.** Always route sweeps through `SweepController`, which implements proper Ed25519 verification via `execute_sweep`, or through the `claim` path which uses Soroban auth instead of off-chain signatures.
 
 ### Other Limitations
 *   **Asset Limit**: The `EphemeralAccount` supports recording up to 10 distinct assets.
@@ -80,8 +95,9 @@ The system employs the Checks-Effects-Interactions pattern and leverages Soroban
 
 ## Best Practices for Integrators
 
-1.  **Use SweepController**: Always use `SweepController::execute_sweep` to perform sweeps. Never call `EphemeralAccount::sweep` directly, as it currently lacks active signature verification.
-2.  **Verify Expiry**: When creating accounts, ensure `expiry_ledger` provides enough buffer for network latency and confirmation times.
-3.  **Monitor Events**: Listen for `AccountCreated` and `PaymentReceived` events to trigger off-chain workflows.
-4.  **Key Management**: Securely manage the Ed25519 private key used for generating sweep signatures. Use a hardware security module (HSM) or secure enclave if possible.
-5.  **Recovery**: Monitor for expired accounts and trigger `expire()` to reclaim funds to the recovery address.
+1.  **Use SweepController**: Always use `SweepController` to perform sweeps — either via `execute_sweep` (Ed25519 signature path) or `claim` (Soroban auth path). Never call `EphemeralAccount::sweep` or `EphemeralAccount::sweep_claim` directly.
+2.  **Choose the Right Path**: Use `execute_sweep` when you have an off-chain signer producing Ed25519 signatures. Use `claim` when the recipient can sign a Soroban auth entry directly (e.g., via SDK or wallet integration).
+3.  **Verify Expiry**: When creating accounts, ensure `expiry_ledger` provides enough buffer for network latency and confirmation times.
+4.  **Monitor Events**: Listen for `AccountCreated`, `PaymentReceived`, and `SweepCompleted` events to trigger off-chain workflows.
+5.  **Key Management**: Securely manage the Ed25519 private key used for generating sweep signatures. Use a hardware security module (HSM) or secure enclave if possible.
+6.  **Recovery**: Monitor for expired accounts and trigger `expire()` to reclaim funds to the recovery address.


### PR DESCRIPTION
## Summary

Documents the two distinct sweep authorization paths to resolve ambiguity about where sweep responsibility lives.

## Changes

### Rustdoc
- `EphemeralAccount::sweep()`: Added detailed documentation explaining this is the Ed25519 signature path, with authorization flow, error variants, and cross-reference to `sweep_claim`
- `EphemeralAccount::sweep_claim()`: Added detailed documentation explaining this is the Soroban auth claim path, with authorization flow, error variants, and cross-reference to `sweep`

### docs/security.md
- Split "Sweep Operations" into **2a. execute_sweep** (Ed25519 signature path) and **2b. claim** (Soroban auth path) with complete flow diagrams for each
- Fixed Known Limitations: removed stale claim that "token transfers are not implemented" -- transfers.rs handles real SEP-41 transfers
- Updated Best Practices to document both sweep paths and when to use each

### Design Decision
Both paths are retained intentionally:
- `execute_sweep`: For automated sweep pipelines with off-chain signers
- `claim`: For SDK/integration-driven claims where the recipient signs directly

Closes #163
