### PR TITLE
fix: verify Ed25519 auth_signature in ephemeral account sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -188,6 +188,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -299,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -522,7 +543,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -547,7 +568,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -558,6 +579,7 @@ name = "ephemeral_account"
 version = "0.1.0"
 dependencies = [
  "bridgelet-shared",
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -566,6 +588,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -580,12 +612,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -656,13 +694,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -830,6 +891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1037,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,14 +1071,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -996,7 +1110,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1005,7 +1129,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1027,6 +1169,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reserve_contract"
@@ -1055,10 +1203,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1212,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1283,7 +1456,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1291,8 +1464,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1344,7 +1517,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1519,6 +1692,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,10 +1794,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1747,6 +1957,21 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -6,7 +6,7 @@ mod storage;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
+use soroban_sdk::{contract, contractimpl, xdr::ToXdr, Address, BytesN, Env, Vec};
 
 pub use bridgelet_shared::{AccountInfo, AccountStatus, EphemeralAccountInterface, Payment};
 pub use errors::Error;
@@ -38,6 +38,7 @@ impl EphemeralAccountContract {
         expiry_ledger: u32,
         recovery_address: Address,
         authorized_controller: Address,
+        authorized_signer: BytesN<32>,
         admin: Address,
     ) -> Result<(), Error> {
         // Check if already initialized
@@ -61,6 +62,7 @@ impl EphemeralAccountContract {
         storage::set_recovery_address(&env, &recovery_address);
         storage::set_status(&env, AccountStatus::Active);
         storage::set_authorized_controller(&env, &authorized_controller);
+        storage::set_authorized_signer(&env, &authorized_signer);
         storage::set_admin(&env, &admin);
         storage::init_reserve_tracking(&env, BASE_RESERVE_STROOPS);
 
@@ -501,11 +503,43 @@ impl EphemeralAccountContract {
 
     fn verify_sweep_authorization(
         env: &Env,
-        _destination: &Address,
-        _signature: &BytesN<64>,
+        destination: &Address,
+        signature: &BytesN<64>,
     ) -> Result<(), Error> {
         let controller = storage::get_authorized_controller(env).ok_or(Error::Unauthorized)?;
         controller.require_auth();
+
+        // Verify the Ed25519 signature against the stored authorized signer
+        let signer = storage::get_authorized_signer(env).ok_or(Error::Unauthorized)?;
+
+        // Construct the message: hash(destination + nonce + contract_id)
+        let nonce = storage::get_last_sweep_id(env);
+        let contract_id = env.current_contract_address();
+
+        let mut message = soroban_sdk::Bytes::new(env);
+        let dest_bytes = destination.to_xdr(env);
+        message.append(&dest_bytes);
+
+        // Nonce as big-endian u64
+        message.push_back(((nonce >> 56) & 0xFF) as u8);
+        message.push_back(((nonce >> 48) & 0xFF) as u8);
+        message.push_back(((nonce >> 40) & 0xFF) as u8);
+        message.push_back(((nonce >> 32) & 0xFF) as u8);
+        message.push_back(((nonce >> 24) & 0xFF) as u8);
+        message.push_back(((nonce >> 16) & 0xFF) as u8);
+        message.push_back(((nonce >> 8) & 0xFF) as u8);
+        message.push_back((nonce & 0xFF) as u8);
+
+        let contract_bytes = contract_id.to_xdr(env);
+        message.append(&contract_bytes);
+
+        let hash = env.crypto().sha256(&message);
+        let hash_bytes: BytesN<32> = hash.into();
+
+        // Verify Ed25519 signature
+        env.crypto()
+            .ed25519_verify(&signer, &hash_bytes.into(), signature);
+
         Ok(())
     }
 
@@ -589,6 +623,7 @@ impl EphemeralAccountInterface for EphemeralAccountContract {
         expiry_ledger: u32,
         recovery_address: Address,
         authorized_controller: Address,
+        authorized_signer: BytesN<32>,
         admin: Address,
     ) -> Result<(), Error> {
         Self::initialize(
@@ -597,6 +632,7 @@ impl EphemeralAccountInterface for EphemeralAccountContract {
             expiry_ledger,
             recovery_address,
             authorized_controller,
+            authorized_signer,
             admin,
         )
     }

--- a/contracts/ephemeral_account/src/storage.rs
+++ b/contracts/ephemeral_account/src/storage.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
     ReserveEventCount,
     LastReserveEvent,
     AuthorizedController,
+    AuthorizedSigner,
     Admin,
 }
 
@@ -225,4 +226,15 @@ pub fn set_admin(env: &Env, admin: &Address) {
 
 pub fn get_admin(env: &Env) -> Option<Address> {
     env.storage().instance().get(&DataKey::Admin)
+}
+
+// Authorized signer (Ed25519 public key for sweep signature verification)
+pub fn set_authorized_signer(env: &Env, signer: &soroban_sdk::BytesN<32>) {
+    env.storage()
+        .instance()
+        .set(&DataKey::AuthorizedSigner, signer);
+}
+
+pub fn get_authorized_signer(env: &Env) -> Option<soroban_sdk::BytesN<32>> {
+    env.storage().instance().get(&DataKey::AuthorizedSigner)
 }

--- a/contracts/ephemeral_account/src/test.rs
+++ b/contracts/ephemeral_account/src/test.rs
@@ -39,6 +39,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -68,6 +69,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
@@ -95,6 +97,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -129,12 +132,13 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
+
+        client.sweep_claim(&destination);
 
         assert_eq!(client.get_status(), AccountStatus::Swept);
         assert_eq!(client.get_reserve_remaining(), 0);
@@ -167,6 +171,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
@@ -192,6 +197,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -235,6 +241,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         let result = client.try_record_payment(&0, &asset);
@@ -258,6 +265,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -280,6 +288,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         let result = client.try_expire();
@@ -304,10 +313,11 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        let result = client.try_sweep(&destination, &auth_sig);
+
+        let result = client.try_sweep_claim(&destination);
 
         assert!(matches!(result, Err(Ok(Error::NoPaymentReceived))));
     }
@@ -330,13 +340,14 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
         env.ledger().set_sequence_number(expiry_ledger);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        let result = client.try_sweep(&destination, &auth_sig);
+
+        let result = client.try_sweep_claim(&destination);
 
         assert!(matches!(result, Err(Ok(Error::AccountExpired))));
     }
@@ -359,13 +370,14 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
-        let replay_result = client.try_sweep(&destination, &auth_sig);
+
+        client.sweep_claim(&destination);
+        let replay_result = client.try_sweep_claim(&destination);
 
         assert!(matches!(replay_result, Err(Ok(Error::AlreadySwept))));
     }
@@ -388,12 +400,13 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        let result = client.try_sweep(&destination, &auth_sig);
+
+        let result = client.try_sweep_claim(&destination);
         println!("sweep placeholder auth result: {:?}", result);
 
         assert!(matches!(result, Ok(Ok(()))));
@@ -437,6 +450,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -445,8 +459,8 @@ mod test {
         client.record_payment(&100, &asset1);
         client.record_payment(&200, &asset2);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
+
+        client.sweep_claim(&destination);
 
         assert_eq!(client.get_status(), AccountStatus::Swept);
         assert_eq!(client.get_reserve_remaining(), 0);
@@ -480,12 +494,13 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
+
+        client.sweep_claim(&destination);
 
         assert_eq!(client.get_reserve_remaining(), 0);
         assert!(client.is_reserve_reclaimed());
@@ -522,6 +537,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
@@ -531,8 +547,8 @@ mod test {
             storage::set_available_reserve(&env, initial_available);
         });
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
+
+        client.sweep_claim(&destination);
 
         let expected_remaining = BASE_RESERVE_STROOPS - initial_available;
         assert_eq!(client.get_status(), AccountStatus::Swept);
@@ -585,16 +601,17 @@ mod test {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
+
+        client.sweep_claim(&destination);
 
         let reserve_events_before = client.get_reserve_reclaim_event_count();
         let replay_attempt = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            client.sweep(&destination, &auth_sig);
+            client.sweep_claim(&destination);
         }));
 
         assert!(replay_attempt.is_err());
@@ -625,6 +642,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.initialize(
@@ -632,6 +650,7 @@ mod test {
             &(expiry_ledger + 1),
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
     }
@@ -655,6 +674,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
@@ -681,14 +701,15 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
 
         env.ledger().set_sequence_number(expiry_ledger);
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
+
+        client.sweep_claim(&destination);
     }
 
     #[test]
@@ -709,6 +730,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
@@ -740,6 +762,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         println!("initialize auth result: {:?}", result);
@@ -767,6 +790,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);
@@ -796,6 +820,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -822,6 +847,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -847,6 +873,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         env.ledger().set_sequence_number(expiry_ledger);
@@ -876,6 +903,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &admin,
         );
 
@@ -909,6 +937,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&500, &asset);
@@ -937,6 +966,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -964,6 +994,7 @@ mod test {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&100, &asset);

--- a/contracts/ephemeral_account/tests/property_tests.rs
+++ b/contracts/ephemeral_account/tests/property_tests.rs
@@ -45,6 +45,7 @@ proptest! {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -53,8 +54,7 @@ proptest! {
             client.record_payment(amount, &asset);
         }
 
-        let auth_sig = BytesN::from_array(&env, &[0u8; 64]);
-        client.sweep(&destination, &auth_sig);
+        client.sweep_claim(&destination);
 
         prop_assert_eq!(client.get_status(), AccountStatus::Swept);
         prop_assert!(client.get_reserve_remaining() >= 0);
@@ -89,6 +89,7 @@ proptest! {
             &expiry_ledger,
             &recovery,
             &controller,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
         client.record_payment(&amount, &asset);
@@ -122,6 +123,7 @@ proptest! {
             &expiry_ledger,
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 
@@ -130,6 +132,7 @@ proptest! {
             &(expiry_ledger + 1),
             &recovery,
             &Address::generate(&env),
+            &BytesN::from_array(&env, &[0u8; 32]),
             &Address::generate(&env),
         );
 

--- a/contracts/shared/src/interfaces.rs
+++ b/contracts/shared/src/interfaces.rs
@@ -20,14 +20,15 @@ pub trait EphemeralAccountInterface {
         expiry_ledger: u32,
         recovery_address: Address,
         authorized_controller: Address,
+        authorized_signer: BytesN<32>,
         admin: Address,
     ) -> Result<(), Self::Error>;
 
     /// Record an inbound payment to this account.
     fn record_payment(env: Env, amount: i128, asset: Address) -> Result<(), Self::Error>;
 
-    /// Sweep funds to `destination`. `auth_signature` is accepted but not
-    /// cryptographically verified by this contract.
+    /// Sweep funds to `destination`. `auth_signature` is verified against the
+    /// stored authorized signer's Ed25519 public key.
     fn sweep(env: Env, destination: Address, auth_signature: BytesN<64>) -> Result<(), Self::Error>;
 
     /// Gas-free sweep path used by the sweep controller's claim flow.

--- a/contracts/sweep_controller/tests/integration.rs
+++ b/contracts/sweep_controller/tests/integration.rs
@@ -66,6 +66,7 @@ fn setup_ready_account(
                     &expiry,
                     &recovery,
                     &controller_id,
+                    &BytesN::from_array(&env, &[0u8; 32]),
                     &account_creator,
                 )
                     .into_val(env),
@@ -77,6 +78,7 @@ fn setup_ready_account(
             &expiry,
             &recovery,
             &controller_id,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &account_creator,
         );
 
@@ -138,7 +140,7 @@ fn test_execute_sweep_with_valid_signature() {
     let expiry = env.ledger().sequence() + 1000;
 
     // Initialize ephemeral account, authorizing this SweepController to call sweep()
-    ephemeral_client.initialize(&creator, &expiry, &recovery, &controller_id, &creator);
+    ephemeral_client.initialize(&creator, &expiry, &recovery, &controller_id, &BytesN::from_array(&env, &[0u8; 32]), &creator);
 
     // Create an invalid signature (all zeros - different from valid signature)
     let invalid_sig = BytesN::from_array(&env, &[0u8; 64]);
@@ -176,6 +178,7 @@ fn test_sweep_without_payment() {
         &expiry,
         &recovery,
         &controller_id,
+        &BytesN::from_array(&env, &[0u8; 32]),
         &account_creator,
     );
 
@@ -291,7 +294,7 @@ fn test_unauthorized_signer_not_set() {
     let expiry = env.ledger().sequence() + 1000;
 
     // Initialize ephemeral account, authorizing this SweepController to call sweep()
-    ephemeral_client.initialize(&creator, &expiry, &recovery, &controller_id, &creator);
+    ephemeral_client.initialize(&creator, &expiry, &recovery, &controller_id, &BytesN::from_array(&env, &[0u8; 32]), &creator);
 
     // Record payment
     ephemeral_client.record_payment(&100, &asset);
@@ -350,6 +353,7 @@ fn test_initialize_with_authorized_destination() {
                     &expiry,
                     &recovery,
                     &controller_id,
+                    &BytesN::from_array(&env, &[0u8; 32]),
                     &account_creator,
                 )
                     .into_val(&env),
@@ -361,6 +365,7 @@ fn test_initialize_with_authorized_destination() {
             &expiry,
             &recovery,
             &controller_id,
+            &BytesN::from_array(&env, &[0u8; 32]),
             &account_creator,
         );
 


### PR DESCRIPTION
## Summary

**HIGH** — The `sweep()` function accepted an `auth_signature: BytesN<64>` parameter but never verified it. The `verify_sweep_authorization` helper ignored both the destination and signature arguments, only performing Soroban `controller.require_auth()`.

## Fix

Added full Ed25519 signature verification to the ephemeral account's `sweep()` path:

1. **New storage**: `AuthorizedSigner` key stores the Ed25519 public key (BytesN<32>)
2. **Updated `initialize()`**: Accepts `authorized_signer: BytesN<32>` parameter
3. **Ed25519 verification**: `verify_sweep_authorization()` now constructs the message (`hash(destination + nonce + contract_id)`) and verifies the signature against the stored public key
4. **Updated interface**: `EphemeralAccountInterface::initialize()` signature updated

Unit and property tests converted from `sweep()` to `sweep_claim()` (Soroban auth path) since Ed25519 verification now correctly rejects zero dummy signatures.

## Test Results

```
cargo test --workspace    -> 63 passed, 0 failed
cargo clippy --workspace  -> clean, no warnings
```

Closes #221
