### PR TITLE
docs: add operational runbooks for emergency destination lock and reserve cross-check

### DIFF
--- a/bridgelet-audit/runbooks/cross-check-reserve-contract-vs-hardcoded-reserve.md
+++ b/bridgelet-audit/runbooks/cross-check-reserve-contract-vs-hardcoded-reserve.md
@@ -1,0 +1,174 @@
+# Cross-Checking ReserveContract's Configured Value Against the Hardcoded Constant
+
+**Runbook type:** Operational  
+**Contracts:** `ReserveContract`, `EphemeralAccount`  
+**Relevant functions / constants:** `ReserveContract::get_base_reserve()`, `BASE_RESERVE_STROOPS = 1_000_000_000`  
+**Tracking issue:** [#292](https://github.com/bridgelet-org/bridgelet-core/issues/292)
+
+---
+
+## Purpose
+
+This runbook describes how an operator confirms whether the base reserve value
+stored in the on-chain `ReserveContract` matches the compile-time constant
+(`BASE_RESERVE_STROOPS`) that `EphemeralAccount` contracts use at initialization.
+
+This comparison **must currently be done manually** because no on-chain logic
+automatically enforces that the two values agree. This runbook frames the check
+as a standing operational responsibility until (if ever) the two are wired
+together in code.
+
+---
+
+## Background
+
+### Two sources of truth for the base reserve
+
+| Source | Location | Visibility | Mutable? |
+|--------|----------|------------|----------|
+| `BASE_RESERVE_STROOPS` compile-time constant | `contracts/ephemeral_account/src/lib.rs` | Compile-time only | Requires a contract redeploy |
+| `ReserveContract::get_base_reserve()` | On-chain `ReserveContract` storage | Readable at any time | Admin can update via `set_base_reserve` |
+
+**Current value of the compile-time constant:**
+
+```rust
+const BASE_RESERVE_STROOPS: i128 = 1_000_000_000; // 100 XLM
+```
+
+When an `EphemeralAccount` is initialized it calls `init_reserve_tracking` with
+exactly this constant. From that moment forward the account tracks reserve
+lifecycle based on `1_000_000_000` stroops, regardless of what `ReserveContract`
+reports.
+
+`ReserveContract` is a separately deployed on-chain store. Its purpose is to
+expose a readable, admin-updatable reference value for the network's base
+reserve. The two values *should* agree, but there is no on-chain assertion that
+enforces this invariant.
+
+---
+
+## When to run this check
+
+Run this verification:
+
+- After any `ReserveContract::set_base_reserve` call.
+- After any redeploy of the `EphemeralAccount` contract (which may change the compile-time constant).
+- As part of a periodic operational audit (recommended: at least monthly, or after any Stellar network upgrade that changes base reserve requirements).
+- Whenever a discrepancy is suspected (e.g. an `EphemeralAccount` reserve reclaim returns an unexpected amount).
+
+---
+
+## Pre-conditions
+
+- [ ] You know the deployed contract ID of the target `ReserveContract` instance.
+- [ ] You know the deployed contract ID (or source code version) of the `EphemeralAccount` instance(s) you are auditing.
+- [ ] You have access to the Stellar CLI or equivalent SDK tooling.
+- [ ] The Stellar network is reachable.
+
+---
+
+## Steps
+
+### 1. Read the on-chain value from `ReserveContract`
+
+```bash
+stellar contract invoke \
+  --id <RESERVE_CONTRACT_ID> \
+  --network <NETWORK> \
+  --source <ANY_ACCOUNT> \
+  -- \
+  get_base_reserve
+```
+
+**Possible outputs:**
+
+| Output | Meaning |
+|--------|---------|
+| `Some(<integer>)` | The admin has set a base reserve; note the value. |
+| `None` | No base reserve has been configured yet on this `ReserveContract`. |
+
+If the result is `None`, the contract has not been initialized with a reserve
+value. This is a misconfiguration that should be remediated before relying on
+this contract as a reference.
+
+---
+
+### 2. Identify the compile-time constant in the deployed `EphemeralAccount`
+
+The constant is set at compile time in the contract source. Check the version
+of the source that was used to build the deployed WASM:
+
+```
+contracts/ephemeral_account/src/lib.rs
+const BASE_RESERVE_STROOPS: i128 = 1_000_000_000;
+```
+
+If you are auditing a live deployment and do not have the source, use the
+deployment artifact metadata or the deployment record in
+`deployments/testnet.json` to identify the commit/tag, then inspect the source
+at that revision.
+
+**Current known value:** `1_000_000_000` stroops (= 100 XLM).
+
+---
+
+### 3. Compare the two values
+
+| Scenario | Interpretation | Action |
+|----------|---------------|--------|
+| `ReserveContract` value equals `BASE_RESERVE_STROOPS` | ✅ Values are consistent. No action required. | Record the check in your audit log. |
+| `ReserveContract` value differs from `BASE_RESERVE_STROOPS` | ⚠️ Values are out of sync. | See remediation guidance below. |
+| `ReserveContract` returns `None` | ⚠️ Reference contract is unconfigured. | Initialize it via `set_base_reserve`. |
+
+---
+
+### 4. (If out of sync) Determine which value is authoritative
+
+Because no on-chain logic automatically reconciles the two, you must determine
+the correct value from context:
+
+- **If the Stellar network base reserve changed:** Update `ReserveContract` to
+  the new network value *and* plan a redeploy of `EphemeralAccount` with an
+  updated constant.
+- **If `ReserveContract` was updated by an admin:** Assess whether the new
+  value is intentional. If it was an error, revert it via another
+  `set_base_reserve` call.
+- **If `EphemeralAccount` was redeployed with a different constant:** Verify
+  the new constant is correct and update `ReserveContract` to match.
+
+Any active `EphemeralAccount` instances initialized before the constant was
+changed will continue to use the old value for the lifetime of those accounts.
+Only newly initialized accounts pick up a redeployed constant.
+
+---
+
+### 5. Record the outcome
+
+Document the result of the check, including:
+
+- Date and time of the check.
+- Network (testnet / mainnet).
+- `ReserveContract` ID queried.
+- `EphemeralAccount` source version / commit audited.
+- Value returned by `get_base_reserve()`.
+- Compile-time constant value.
+- Whether values matched.
+- Any remediation steps taken.
+
+---
+
+## Limitations and caveats
+
+- **No automatic enforcement.** Nothing on-chain prevents the two values from
+  diverging. This check is purely manual and advisory.
+- **Per-account snapshot.** Each `EphemeralAccount` captures `BASE_RESERVE_STROOPS`
+  at initialization time. If the constant changes, already-initialized accounts
+  are unaffected — only new accounts pick up the new value.
+- **Standing check.** Until the two sources are wired together in contract code,
+  this check should remain part of the regular operational runbook rotation.
+
+---
+
+## Related runbooks
+
+- [`emergency-destination-lock.md`](./emergency-destination-lock.md) — Lock down the sweep destination during a key compromise.

--- a/bridgelet-audit/runbooks/emergency-destination-lock.md
+++ b/bridgelet-audit/runbooks/emergency-destination-lock.md
@@ -1,0 +1,168 @@
+# Emergency Destination Lock
+
+**Runbook type:** Operational  
+**Contract:** `SweepController`  
+**Relevant functions:** `update_authorized_destination()`, `has_authorized_destination()`, `get_authorized_destination()`  
+**Tracking issue:** [#284](https://github.com/bridgelet-org/bridgelet-core/issues/284)
+
+---
+
+## Purpose
+
+This runbook describes the steps an operator takes to lock down—or replace—the
+`authorized_destination` stored in a `SweepController` instance when a private
+key compromise is suspected or confirmed.
+
+It is a **purely descriptive** record of current on-chain behavior. No code
+changes are proposed or required to execute these steps.
+
+---
+
+## Background
+
+`SweepController` can be deployed in two modes:
+
+| Mode | `authorized_destination` | Who can receive swept funds |
+|------|--------------------------|-----------------------------|
+| Flexible | Not set | Any destination passed to `execute_sweep` |
+| Locked | Set to a specific address | Only that address |
+
+When the contract is in **locked mode**, every call to `execute_sweep` is
+rejected unless the `destination` argument matches the stored address. If the
+wallet controlling the locked destination is compromised, the operator must
+replace that address before any attacker can attempt a sweep.
+
+The update window is controlled by a single invariant:
+
+> **`update_authorized_destination` can only be called while the sweep nonce
+> is still `0`.**  Once any sweep has been executed the nonce increments to `1`
+> (or higher) and further updates are permanently blocked with
+> `Error::AccountAlreadySwept`.
+
+---
+
+## Pre-conditions
+
+Before executing these steps, confirm all of the following:
+
+- [ ] You have access to the **creator** key that was used when `SweepController::initialize` was called.
+- [ ] No sweep has yet been executed against this controller (sweep nonce = 0).  
+      *If the nonce is already > 0, no destination update is possible — escalate immediately.*
+- [ ] You have identified a **safe replacement destination** address and confirmed you control it.
+- [ ] The Stellar network is reachable and you have sufficient XLM on the creator account for transaction fees.
+
+---
+
+## Steps
+
+### 1. Confirm no sweep has occurred yet
+
+Query the contract's sweep nonce via the Stellar CLI or your preferred SDK.
+If the nonce is **not 0**, stop here — `update_authorized_destination` will
+revert with `Error::AccountAlreadySwept`. Treat this as an incident and
+escalate according to your incident-response process.
+
+```bash
+# Using stellar-cli (replace placeholders with real values)
+stellar contract invoke \
+  --id <SWEEP_CONTROLLER_CONTRACT_ID> \
+  --network <NETWORK> \
+  --source <CREATOR_SECRET_KEY> \
+  -- \
+  get_sweep_nonce
+```
+
+Expected output when safe to proceed: `0`
+
+---
+
+### 2. Call `update_authorized_destination`
+
+Submit a transaction signed by the **creator** key that calls
+`update_authorized_destination` with the replacement address.
+
+```bash
+stellar contract invoke \
+  --id <SWEEP_CONTROLLER_CONTRACT_ID> \
+  --network <NETWORK> \
+  --source <CREATOR_SECRET_KEY> \
+  -- \
+  update_authorized_destination \
+  --new_destination <REPLACEMENT_DESTINATION_ADDRESS>
+```
+
+A successful invocation emits a `DestinationUpdated` event containing:
+- `old_destination` — the address being replaced (or `None` if none was set)
+- `new_destination` — the replacement address you supplied
+
+If the call fails with `Error::AuthorizationFailed`, check that the signing key
+matches the creator recorded at initialization. If it fails with
+`Error::AccountAlreadySwept`, the nonce is no longer 0 (see step 1).
+
+---
+
+### 3. Verify the new destination is active
+
+After the transaction confirms, call both read-only helpers to verify the
+state reflects the update:
+
+**3a. Confirm a destination is now set**
+
+```bash
+stellar contract invoke \
+  --id <SWEEP_CONTROLLER_CONTRACT_ID> \
+  --network <NETWORK> \
+  --source <ANY_ACCOUNT> \
+  -- \
+  has_authorized_destination
+```
+
+Expected output: `true`
+
+**3b. Confirm it matches the replacement address**
+
+```bash
+stellar contract invoke \
+  --id <SWEEP_CONTROLLER_CONTRACT_ID> \
+  --network <NETWORK> \
+  --source <ANY_ACCOUNT> \
+  -- \
+  get_authorized_destination
+```
+
+Expected output: `<REPLACEMENT_DESTINATION_ADDRESS>`
+
+If either result is unexpected, do **not** proceed. Halt all sweep operations
+and investigate.
+
+---
+
+### 4. Revoke access to the compromised key
+
+Once the on-chain destination is updated, take all off-chain steps to revoke
+the compromised key:
+
+- Remove the old private key from all key stores, HSMs, and configuration files.
+- Rotate any secrets that were co-located with the compromised key.
+- Notify stakeholders according to your incident-response policy.
+
+---
+
+## Limitations and caveats
+
+- **One-time window.** The `authorized_destination` can only be updated when
+  `sweep_nonce == 0`. There is no on-chain mechanism to re-open this window
+  after a sweep occurs. This behavior is intentional and is not proposed to
+  change in this runbook.
+- **Flexible mode.** If the controller was deployed without an initial
+  `authorized_destination` (flexible mode), calling `update_authorized_destination`
+  will *set* a destination for the first time, effectively locking the contract.
+  The same nonce-zero constraint applies.
+- **Monitoring.** Off-chain event indexers should watch for `DestinationUpdated`
+  events on all active `SweepController` instances to detect unexpected changes.
+
+---
+
+## Related runbooks
+
+- [`cross-check-reserve-contract-vs-hardcoded-reserve.md`](./cross-check-reserve-contract-vs-hardcoded-reserve.md) — Verify on-chain reserve configuration.


### PR DESCRIPTION
## Summary

Adds two operational runbooks to `bridgelet-audit/runbooks/` as part of the bridgelet-audit knowledge-base initiative.

> Supersedes #377 (same content, rebased cleanly onto current upstream `main` to fix the CI workspace.dependencies issue).

## Changes

### `emergency-destination-lock.md` (closes #284)
Operational runbook for locking down `SweepController`'s `authorized_destination` during a suspected key compromise.

Covers:
- Pre-conditions and nonce check before attempting an update
- Calling `update_authorized_destination()` with a replacement address (only available while sweep nonce == 0)
- Verification steps using `has_authorized_destination()` and `get_authorized_destination()`
- Post-update key revocation steps
- Limitations: the update window closes permanently once a sweep has executed

### `cross-check-reserve-contract-vs-hardcoded-reserve.md` (closes #292)
Operational runbook for manually comparing `ReserveContract::get_base_reserve()` against the `BASE_RESERVE_STROOPS` compile-time constant (`1_000_000_000` stroops = 100 XLM).

Covers:
- Querying the on-chain value via `get_base_reserve()`
- Identifying the compile-time constant in the deployed `EphemeralAccount` source
- Comparison matrix with remediation guidance for each outcome
- When to run the check (after admin updates, redeploys, or periodic audits)
- Framed as a standing operational check because no on-chain logic currently enforces the two values are in sync

## Scope

Documentation-only. No changes to `contracts/`, `docs/`, `scripts/`, or `tools/`.

## CI

Branch is based on current upstream `main` (commit 7923683). All contract source is unchanged — `cargo test`, `cargo fmt --check`, `cargo clippy`, and `stellar contract build` will pass.

Closes #284
Closes #292