### PR TITLE
fix: increment nonce in claim path and catch ed25519 panic

### DIFF
--- a/contracts/sweep_controller/src/authorization.rs
+++ b/contracts/sweep_controller/src/authorization.rs
@@ -64,20 +64,21 @@ pub fn verify_sweep_auth(
     destination: &Address,
     signature: &BytesN<64>,
 ) -> Result<(), Error> {
-    // Get the authorized signer public key from storage
     let authorized_signer =
         storage::get_authorized_signer(env).ok_or(Error::AuthorizedSignerNotSet)?;
 
-    // Get the sweep controller contract address
     let contract_id = env.current_contract_address();
-
-    // Construct the message that should have been signed
     let message = construct_sweep_message(env, destination, &contract_id);
 
-    // Verify the Ed25519 signature
-    env.crypto()
-        .ed25519_verify(&authorized_signer, &message.into(), signature);
-    Ok(())
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        env.crypto()
+            .ed25519_verify(&authorized_signer, &message.into(), signature);
+    }));
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(_) => Err(Error::AuthorizationFailed),
+    }
 }
 
 /// Increment the nonce after successful authorization

--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -110,6 +110,7 @@ impl SweepController {
         let amount: i128 = info.payments.iter().map(|p| p.amount).sum();
 
         Self::authorize_claim(&env, &ephemeral_account, &recipient)?;
+        authorization::increment_nonce(&env);
         emit_sweep_completed(&env, ephemeral_account, recipient, amount);
 
         Ok(())


### PR DESCRIPTION
## Summary

**CRITICAL (#229)**: `claim()` did not call `increment_nonce()`, allowing replay attacks via repeated claim calls.

**HIGH (#230)**: `verify_sweep_auth` called `ed25519_verify` directly, which panics on invalid signatures.

## Changes

- `sweep_controller/src/lib.rs`: Add `authorization::increment_nonce()` after successful claim
- `sweep_controller/src/authorization.rs`: Wrap `ed25519_verify` in `std::panic::catch_unwind`

Closes #229
Closes #230
