### PR TITLE
fix: namespace contract error codes into per-contract 1000-wide block…

### DIFF
--- a/contracts/ephemeral_account/src/errors.rs
+++ b/contracts/ephemeral_account/src/errors.rs
@@ -1,22 +1,29 @@
 use soroban_sdk::contracterror;
 
+// Issue #248: error codes are namespaced per contract to avoid ambiguity
+// when a raw numeric code is surfaced without its originating contract ID.
+// Namespace map (1000-wide blocks):
+//   ephemeral_account -> 1000-1999
+//   sweep_controller   -> 2000-2999
+//   reserve_contract   -> 3000-3999
+//   account_factory    -> 4000-4999 (reserved for future use)
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
-    AlreadyInitialized = 1,
-    NotInitialized = 2,
-    PaymentAlreadyReceived = 3,
-    InvalidAmount = 4,
-    InvalidExpiry = 5,
-    NotExpired = 6,
-    AlreadySwept = 7,
-    Unauthorized = 8,
-    InvalidSignature = 9,
-    NoPaymentReceived = 10,
-    AccountExpired = 11,
-    InvalidStatus = 12,
-    DuplicateAsset = 13,
-    TooManyPayments = 14,
-    NotUpgradeAdmin = 15,
+    AlreadyInitialized = 1000,
+    NotInitialized = 1001,
+    PaymentAlreadyReceived = 1002,
+    InvalidAmount = 1003,
+    InvalidExpiry = 1004,
+    NotExpired = 1005,
+    AlreadySwept = 1006,
+    Unauthorized = 1007,
+    InvalidSignature = 1008,
+    NoPaymentReceived = 1009,
+    AccountExpired = 1010,
+    InvalidStatus = 1011,
+    DuplicateAsset = 1012,
+    TooManyPayments = 1013,
+    NotUpgradeAdmin = 1014,
 }

--- a/contracts/ephemeral_account/src/test.rs
+++ b/contracts/ephemeral_account/src/test.rs
@@ -401,21 +401,22 @@ mod test {
 
     #[test]
     fn test_error_variants_have_expected_numeric_codes() {
-        assert_eq!(Error::AlreadyInitialized as u32, 1);
-        assert_eq!(Error::NotInitialized as u32, 2);
-        assert_eq!(Error::PaymentAlreadyReceived as u32, 3);
-        assert_eq!(Error::InvalidAmount as u32, 4);
-        assert_eq!(Error::InvalidExpiry as u32, 5);
-        assert_eq!(Error::NotExpired as u32, 6);
-        assert_eq!(Error::AlreadySwept as u32, 7);
-        assert_eq!(Error::Unauthorized as u32, 8);
-        assert_eq!(Error::InvalidSignature as u32, 9);
-        assert_eq!(Error::NoPaymentReceived as u32, 10);
-        assert_eq!(Error::AccountExpired as u32, 11);
-        assert_eq!(Error::InvalidStatus as u32, 12);
-        assert_eq!(Error::DuplicateAsset as u32, 13);
-        assert_eq!(Error::TooManyPayments as u32, 14);
-        assert_eq!(Error::NotUpgradeAdmin as u32, 15);
+        // Issue #248: this contract's error codes are namespaced to 1000-1999.
+        assert_eq!(Error::AlreadyInitialized as u32, 1000);
+        assert_eq!(Error::NotInitialized as u32, 1001);
+        assert_eq!(Error::PaymentAlreadyReceived as u32, 1002);
+        assert_eq!(Error::InvalidAmount as u32, 1003);
+        assert_eq!(Error::InvalidExpiry as u32, 1004);
+        assert_eq!(Error::NotExpired as u32, 1005);
+        assert_eq!(Error::AlreadySwept as u32, 1006);
+        assert_eq!(Error::Unauthorized as u32, 1007);
+        assert_eq!(Error::InvalidSignature as u32, 1008);
+        assert_eq!(Error::NoPaymentReceived as u32, 1009);
+        assert_eq!(Error::AccountExpired as u32, 1010);
+        assert_eq!(Error::InvalidStatus as u32, 1011);
+        assert_eq!(Error::DuplicateAsset as u32, 1012);
+        assert_eq!(Error::TooManyPayments as u32, 1013);
+        assert_eq!(Error::NotUpgradeAdmin as u32, 1014);
     }
 
     #[test]
@@ -608,7 +609,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #1)")]
+    #[should_panic(expected = "Error(Contract, #1000)")]
     fn test_double_initialize_is_rejected() {
         let env = Env::default();
         env.mock_all_auths();
@@ -637,7 +638,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #13)")]
+    #[should_panic(expected = "Error(Contract, #1012)")]
     fn test_double_payment_for_same_asset_is_rejected() {
         let env = Env::default();
         env.mock_all_auths();
@@ -662,7 +663,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #11)")]
+    #[should_panic(expected = "Error(Contract, #1010)")]
     fn test_sweep_after_expiry_is_rejected() {
         let env = Env::default();
         env.mock_all_auths();

--- a/contracts/reserve_contract/src/errors.rs
+++ b/contracts/reserve_contract/src/errors.rs
@@ -1,39 +1,42 @@
 use soroban_sdk::contracterror;
 
+// Issue #248: error codes are namespaced per contract. See
+// contracts/ephemeral_account/src/errors.rs for the full namespace map.
+// This contract owns 3000-3999.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Error {
     /// The supplied amount is zero or negative; only positive stroops are valid.
-    InvalidAmount = 1,
+    InvalidAmount = 3000,
 
     /// A read operation was attempted before any base reserve was stored.
     ///
     /// Callers should check [`ReserveContract::has_base_reserve`] or use the
     /// `Option`-returning [`ReserveContract::get_base_reserve`] instead of
     /// any helper that returns a bare value.
-    ReserveNotSet = 2,
+    ReserveNotSet = 3001,
 
     /// The caller is not the admin set during initialization.
     ///
     /// Only the admin address provided in [`ReserveContract::initialize`] may
     /// call state-changing operations such as [`ReserveContract::set_base_reserve`].
-    Unauthorized = 3,
+    Unauthorized = 3002,
 
     /// [`ReserveContract::initialize`] was called more than once.
     ///
     /// The contract may only be initialized once; subsequent calls are rejected
     /// to prevent admin takeover.
-    AlreadyInitialized = 4,
+    AlreadyInitialized = 3003,
 
     /// A state-changing operation was attempted before [`ReserveContract::initialize`]
     /// was called.
-    NotInitialized = 5,
+    NotInitialized = 3004,
 
     /// The supplied amount exceeds the maximum allowed value.
     ///
     /// An upper bound prevents accidental misconfiguration
     /// (e.g. storing a value in XLM instead of stroops).
     /// Current ceiling: 10,000 XLM = 100_000_000_000 stroops.
-    AmountTooLarge = 6,
+    AmountTooLarge = 3005,
 }

--- a/contracts/reserve_contract/src/test.rs
+++ b/contracts/reserve_contract/src/test.rs
@@ -79,7 +79,7 @@ mod test {
 
     /// Double initialization must fail with error #4 (AlreadyInitialized).
     #[test]
-    #[should_panic(expected = "Error(Contract, #4)")]
+    #[should_panic(expected = "Error(Contract, #3003)")]
     fn test_initialize_twice_panics() {
         let (env, client, _admin, _) = setup();
         let another = Address::generate(&env);
@@ -91,7 +91,7 @@ mod test {
     /// set_base_reserve must fail with error #5 (NotInitialized) on a fresh
     /// contract that was never initialized.
     #[test]
-    #[should_panic(expected = "Error(Contract, #5)")]
+    #[should_panic(expected = "Error(Contract, #3004)")]
     fn test_set_base_reserve_before_initialize_panics() {
         let (_env, client, _) = setup_uninitialized();
         client.set_base_reserve(&1_000_000_000i128);
@@ -117,7 +117,7 @@ mod test {
 
     /// require_base_reserve() must panic (contract error #2) when not set.
     #[test]
-    #[should_panic(expected = "Error(Contract, #2)")]
+    #[should_panic(expected = "Error(Contract, #3001)")]
     fn test_require_base_reserve_panics_when_not_set() {
         let (_env, client, _) = setup_uninitialized();
         client.require_base_reserve();
@@ -170,7 +170,7 @@ mod test {
 
     /// Zero is not a valid reserve; the contract must reject it with error #1.
     #[test]
-    #[should_panic(expected = "Error(Contract, #1)")]
+    #[should_panic(expected = "Error(Contract, #3000)")]
     fn test_set_base_reserve_zero_is_rejected() {
         let (_env, client, _admin, _) = setup();
         client.set_base_reserve(&0i128);
@@ -178,7 +178,7 @@ mod test {
 
     /// Negative amounts are nonsensical and must be rejected with error #1.
     #[test]
-    #[should_panic(expected = "Error(Contract, #1)")]
+    #[should_panic(expected = "Error(Contract, #3000)")]
     fn test_set_base_reserve_negative_is_rejected() {
         let (_env, client, _admin, _) = setup();
         client.set_base_reserve(&-1i128);
@@ -186,7 +186,7 @@ mod test {
 
     /// A large negative amount (i128::MIN) must also be rejected.
     #[test]
-    #[should_panic(expected = "Error(Contract, #1)")]
+    #[should_panic(expected = "Error(Contract, #3000)")]
     fn test_set_base_reserve_min_i128_is_rejected() {
         let (_env, client, _admin, _) = setup();
         client.set_base_reserve(&i128::MIN);
@@ -207,7 +207,7 @@ mod test {
 
     /// One stroop above the ceiling must be rejected with error #6.
     #[test]
-    #[should_panic(expected = "Error(Contract, #6)")]
+    #[should_panic(expected = "Error(Contract, #3005)")]
     fn test_set_base_reserve_above_max_is_rejected() {
         let (_env, client, _admin, _) = setup();
         client.set_base_reserve(&100_000_000_001i128);
@@ -215,7 +215,7 @@ mod test {
 
     /// An absurdly large value must be rejected with error #6.
     #[test]
-    #[should_panic(expected = "Error(Contract, #6)")]
+    #[should_panic(expected = "Error(Contract, #3005)")]
     fn test_set_base_reserve_huge_value_is_rejected() {
         let (_env, client, _admin, _) = setup();
         client.set_base_reserve(&i128::MAX);

--- a/contracts/sweep_controller/src/errors.rs
+++ b/contracts/sweep_controller/src/errors.rs
@@ -1,18 +1,23 @@
 use soroban_sdk::contracterror;
 
+// Issue #248: error codes are namespaced per contract. See
+// contracts/ephemeral_account/src/errors.rs for the full namespace map.
+// This contract owns 2000-2999. Note: 2011 is intentionally skipped here,
+// preserving the original enum's internal gap.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
 pub enum Error {
-    InvalidAccount = 1,
-    TransferFailed = 2,
-    AuthorizationFailed = 3,
-    InsufficientBalance = 4,
-    AccountNotReady = 5,
-    AccountExpired = 6,
-    AccountAlreadySwept = 7,
-    InvalidSignature = 8,
-    SignatureVerificationFailed = 9,
-    AuthorizedSignerNotSet = 10,
-    InvalidNonce = 11,
-    UnauthorizedDestination = 13,
+    InvalidAccount = 2000,
+    TransferFailed = 2001,
+    AuthorizationFailed = 2002,
+    InsufficientBalance = 2003,
+    AccountNotReady = 2004,
+    AccountExpired = 2005,
+    AccountAlreadySwept = 2006,
+    InvalidSignature = 2007,
+    SignatureVerificationFailed = 2008,
+    AuthorizedSignerNotSet = 2009,
+    InvalidNonce = 2010,
+    UnauthorizedDestination = 2012,
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -287,20 +287,25 @@ fn get_reserve_reclaim_event_count(env: Env) -> u32
 
 | Code | Variant | Description |
 | :--- | :--- | :--- |
-| 1 | `AlreadyInitialized` | Contract already initialized. |
-| 2 | `NotInitialized` | Contract not initialized. |
-| 3 | `PaymentAlreadyReceived` | Deprecated. Use `DuplicateAsset` (code 13). |
-| 4 | `InvalidAmount` | Payment amount is zero or negative. |
-| 5 | `InvalidExpiry` | `expiry_ledger` is not in the future. |
-| 6 | `NotExpired` | Attempted to expire before `expiry_ledger`. |
-| 7 | `AlreadySwept` | Account already swept. |
-| 8 | `Unauthorized` | `authorized_controller` did not authorize the call. |
-| 9 | `InvalidSignature` | Cryptographic signature format is invalid. |
-| 10 | `NoPaymentReceived` | Cannot sweep without a recorded payment. |
-| 11 | `AccountExpired` | Cannot sweep an expired account. |
-| 12 | `InvalidStatus` | Action is invalid for the current account status. |
-| 13 | `DuplicateAsset` | Asset already has a recorded payment. |
-| 14 | `TooManyPayments` | Maximum of 10 distinct assets reached. |
+As of [Issue #248](https://github.com/bridgelet-org/bridgelet-core/issues/248), error codes are namespaced per contract in 1000-wide blocks so a bare numeric code is never ambiguous across contracts. This contract owns the 1000-1999 range.
+
+| Code | Variant | Description |
+| :--- | :--- | :--- |
+| 1000 | `AlreadyInitialized` | Contract already initialized. |
+| 1001 | `NotInitialized` | Contract not initialized. |
+| 1002 | `PaymentAlreadyReceived` | Deprecated. Use `DuplicateAsset` (code 1012). |
+| 1003 | `InvalidAmount` | Payment amount is zero or negative. |
+| 1004 | `InvalidExpiry` | `expiry_ledger` is not in the future. |
+| 1005 | `NotExpired` | Attempted to expire before `expiry_ledger`. |
+| 1006 | `AlreadySwept` | Account already swept. |
+| 1007 | `Unauthorized` | `authorized_controller` did not authorize the call. |
+| 1008 | `InvalidSignature` | Cryptographic signature format is invalid. |
+| 1009 | `NoPaymentReceived` | Cannot sweep without a recorded payment. |
+| 1010 | `AccountExpired` | Cannot sweep an expired account. |
+| 1011 | `InvalidStatus` | Action is invalid for the current account status. |
+| 1012 | `DuplicateAsset` | Asset already has a recorded payment. |
+| 1013 | `TooManyPayments` | Maximum of 10 distinct assets reached. |
+| 1014 | `NotUpgradeAdmin` | Caller is not authorized to perform contract upgrades. |
 
 ---
 
@@ -479,18 +484,22 @@ fn update_authorized_destination(env: Env, new_destination: Address) -> Result<(
 
 | Code | Variant | Description |
 | :--- | :--- | :--- |
-| 1 | `InvalidAccount` | Account is not in a valid state for the requested operation. |
-| 2 | `TransferFailed` | A SEP-41 token transfer failed. |
-| 3 | `AuthorizationFailed` | Signature invalid, caller not authorized, or already initialized. |
-| 4 | `InsufficientBalance` | Reserved for future use. |
-| 5 | `AccountNotReady` | Account has no payments or zero total amount. |
-| 6 | `AccountExpired` | Account has expired. |
-| 7 | `AccountAlreadySwept` | A sweep has already been executed; destination cannot be changed. |
-| 8 | `InvalidSignature` | Signature format is invalid. |
-| 9 | `SignatureVerificationFailed` | Ed25519 verification failure. |
-| 10 | `AuthorizedSignerNotSet` | Controller was not initialized with an authorized signer. |
-| 11 | `InvalidNonce` | Security nonce is invalid or out of sequence. |
-| 13 | `UnauthorizedDestination` | Destination does not match the locked `authorized_destination`. |
+Per [Issue #248](https://github.com/bridgelet-org/bridgelet-core/issues/248), this contract owns the 2000-2999 error code range. Code 2011 is intentionally unused, preserving a gap from the original enum.
+
+| Code | Variant | Description |
+| :--- | :--- | :--- |
+| 2000 | `InvalidAccount` | Account is not in a valid state for the requested operation. |
+| 2001 | `TransferFailed` | A SEP-41 token transfer failed. |
+| 2002 | `AuthorizationFailed` | Signature invalid, caller not authorized, or already initialized. |
+| 2003 | `InsufficientBalance` | Reserved for future use. |
+| 2004 | `AccountNotReady` | Account has no payments or zero total amount. |
+| 2005 | `AccountExpired` | Account has expired. |
+| 2006 | `AccountAlreadySwept` | A sweep has already been executed; destination cannot be changed. |
+| 2007 | `InvalidSignature` | Signature format is invalid. |
+| 2008 | `SignatureVerificationFailed` | Ed25519 verification failure. |
+| 2009 | `AuthorizedSignerNotSet` | Controller was not initialized with an authorized signer. |
+| 2010 | `InvalidNonce` | Security nonce is invalid or out of sequence. |
+| 2012 | `UnauthorizedDestination` | Destination does not match the locked `authorized_destination`. |
 
 ---
 


### PR DESCRIPTION
…s (#248)

- ephemeral_account owns 1000-1999, reserve_contract owns 3000-3999, sweep_controller owns 2000-2999
- renumbered discriminants in each contract's errors.rs
- updated should_panic test expectations to match new 4-digit codes
- updated docs/api-reference.md error code tables for all contracts
- preserved intentional gaps (e.g. 2011) from the original enums

closes #248 