### PR TITLE
fix(account_factory): secure initialize, monotonic batch salts, real tests, accurate reentrancy doc

### DIFF
--- a/contracts/account_factory/src/errors.rs
+++ b/contracts/account_factory/src/errors.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// `initialize` was called more than once, or after the factory was
+    /// already configured. Without this guard, any caller could overwrite
+    /// `EphemeralAccountWasmHash` with a malicious contract wasm (issue #240).
+    AlreadyInitialized = 1,
+    /// A factory entry point was invoked before `initialize` succeeded.
+    /// Currently only reachable from `batch_initialize` when invoked without a
+    /// prior `initialize`, since the factory uses a hard `unwrap()` on the
+    /// stored wasm hash so the contract decides to panic rather than silently
+    /// skip the batch.
+    NotInitialized = 2,
+}

--- a/contracts/account_factory/src/lib.rs
+++ b/contracts/account_factory/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use bridgelet_shared::{AccountInitRequest, AccountInitResult};
-
 mod ephemeral_account_contract {
     soroban_sdk::contractimport!(
         file = "../../target/wasm32v1-none/release/ephemeral_account.wasm"
@@ -9,6 +7,13 @@ mod ephemeral_account_contract {
 }
 use ephemeral_account_contract::Client as EphemeralAccountClient;
 
+mod errors;
+pub use errors::Error;
+
+#[cfg(test)]
+mod test;
+
+use bridgelet_shared::{AccountInitRequest, AccountInitResult};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Vec};
 
 #[contract]
@@ -16,25 +21,69 @@ pub struct AccountFactory;
 
 #[contractimpl]
 impl AccountFactory {
-    /// Initialize the factory contract (store the ephemeral account contract wasm hash)
+    /// Initialize the factory contract (store the ephemeral account contract wasm hash).
+    ///
+    /// This entry point is **single-shot**: it requires the creator (deployment
+    /// authorizer) to provide its address and prove authorization, and it
+    /// rejects any second call once the WASM hash has been written (issue
+    /// #240). Without these guards any caller could overwrite the stored WASM
+    /// hash with a malicious contract before the legitimate operator.
     ///
     /// # Arguments
-    /// * `ephemeral_account_wasm_hash` - Hash of the ephemeral account contract wasm
-    pub fn initialize(env: Env, ephemeral_account_wasm_hash: BytesN<32>) {
+    /// * `creator` - Authorizing address; the only caller permitted to set the
+    ///   factory's WASM hash. Must produce a valid Soroban auth entry.
+    /// * `ephemeral_account_wasm_hash` - Hash of the ephemeral account
+    ///   contract WASM that subsequent `batch_initialize` calls will deploy.
+    ///
+    /// # Errors
+    /// * `Error::AlreadyInitialized` - factory has already been initialized.
+    pub fn initialize(
+        env: Env,
+        creator: Address,
+        ephemeral_account_wasm_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        // State check fires BEFORE require_auth so a double-init attempt from
+        // any caller is rejected without paying the cost of an auth entry.
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::EphemeralAccountWasmHash)
+        {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        // Creator must authorize the write. After the guard fires above, this
+        // is the only call that ever sets the WASM hash.
+        creator.require_auth();
+
         env.storage().instance().set(
             &DataKey::EphemeralAccountWasmHash,
             &ephemeral_account_wasm_hash,
         );
+        env.storage().instance().set(&DataKey::BatchNonce, &0u64);
+
+        Ok(())
     }
 
-    /// Batch initialize multiple ephemeral accounts in a single transaction
+    /// Batch initialize multiple ephemeral accounts in a single transaction.
     ///
     /// # Arguments
     /// * `creator` - Address creating all accounts
-    /// * `requests` - Vector of AccountInitRequest
+    /// * `requests` - Vector of [`AccountInitRequest`].
+    ///
+    /// # Salt uniqueness (issue #241)
+    /// `Soroban`'s `deployer().with_current_contract(salt)` derives a contract
+    /// address deterministically from `(factory_address, salt, wasm_hash)`. A
+    /// salt that depended only on the per-batch index would collide the
+    /// second time `batch_initialize` was invoked with a request at index 0,
+    /// because the loop would once again produce `salt = [0, ..., index]`.
+    /// We therefore mix a monotonic per-factory-call counter
+    /// (`DataKey::BatchNonce`) into the high bytes of the salt so that
+    /// distinct invocations of `batch_initialize` always produce disjoint
+    /// address ranges, even at the same index.
     ///
     /// # Returns
-    /// Vector of AccountInitResult
+    /// Vector of [`AccountInitResult`] preserving the input order.
     pub fn batch_initialize(
         env: Env,
         creator: Address,
@@ -46,13 +95,35 @@ impl AccountFactory {
             .storage()
             .instance()
             .get::<_, BytesN<32>>(&DataKey::EphemeralAccountWasmHash)
-            .unwrap();
+            .expect("factory not initialized; call initialize() first");
+
+        // Bump the per-factory-call nonce exactly once per invocation.
+        // The combined `nonce || index` salt ensures no two deployments from
+        // separate calls ever produce the same address, while still being
+        // deterministic within a single call.
+        let prev_nonce: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::BatchNonce)
+            .unwrap_or(0);
+        // u64 + 1 cannot overflow for any realistic call count. The workspace
+        // enables `overflow-checks = true` in release, so any overflow would
+        // surface as a panic rather than a silent wraparound to a colliding
+        // salt.
+        let nonce = prev_nonce + 1u64;
+        env.storage().instance().set(&DataKey::BatchNonce, &nonce);
 
         let mut results = Vec::new(&env);
 
         for (index, request) in requests.iter().enumerate() {
-            // Deploy a new ephemeral account contract with unique salt
+            // Salt layout (32 bytes, big-endian):
+            //   [0..8]  nonce   — monotonically increases each call to
+            //                     batch_initialize
+            //   [8..28] zeros  — reserved (kept zero to leave room for future
+            //                    fields such as a creator-tag)
+            //   [28..32] index — per-request position inside the call
             let mut salt_bytes = [0u8; 32];
+            salt_bytes[0..8].copy_from_slice(&nonce.to_be_bytes());
             salt_bytes[28..32].copy_from_slice(&(index as u32).to_be_bytes());
             let salt = BytesN::from_array(&env, &salt_bytes);
             let account_address = env
@@ -92,4 +163,8 @@ impl AccountFactory {
 #[contracttype]
 enum DataKey {
     EphemeralAccountWasmHash,
+    /// Monotonically increasing counter incremented once per call to
+    /// `batch_initialize`. Mixed into the deployment salt to keep addresses
+    /// disjoint across separate invocations (issue #241).
+    BatchNonce,
 }

--- a/contracts/account_factory/src/test.rs
+++ b/contracts/account_factory/src/test.rs
@@ -1,44 +1,227 @@
-#![cfg(test)]
-
 extern crate std;
 
 use super::*;
-use bridgelet_shared::{AccountInitRequest, AccountInitResult};
+use bridgelet_shared::AccountInitRequest;
 use ephemeral_account::EphemeralAccountContract;
-use soroban_sdk::{testutils::Address as _, vec, Address, BytesN, Env};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, InvokeError};
+
+// Include the compiled ephemeral account WASM so the factory can deploy it
+// during tests without depending on `stellar contract build` having run.
+// Path is relative to `contracts/account_factory/src/test.rs`.
+const EPHEMERAL_ACCOUNT_WASM: &[u8] =
+    include_bytes!("../../../target/wasm32v1-none/release/ephemeral_account.wasm");
+
+/// Upload the ephemeral account WASM into the test env, returning both the
+/// WASM hash (which the factory will forward to `deploy_v2`) and the
+/// template contract id (used for direct SDK calls when convenient).
+fn register_template(env: &Env) -> (BytesN<32>, Address) {
+    let wasm_hash = env.deployer().upload_contract_wasm(EPHEMERAL_ACCOUNT_WASM);
+    let template_id = env.register(EphemeralAccountContract, ());
+    (wasm_hash, template_id)
+}
+
+fn build_requests(env: &Env, count: u32) -> (u32, Vec<AccountInitRequest>) {
+    let expiry = env.ledger().sequence() + 1000;
+    let mut reqs = Vec::new(env);
+    for i in 0..count {
+        reqs.push_back(AccountInitRequest {
+            expiry_ledger: expiry + i,
+            recovery_address: Address::generate(env),
+        });
+    }
+    (expiry, reqs)
+}
+
+/// Assert that a slice of addresses contains no duplicates. `Soroban`'s
+/// `Address` does not implement std's `Hash`, so we use a Vec + linear scan.
+/// The per-batch sizes in these tests are small (≤ 5), so this is O(n²).
+fn assert_unique_addresses(addresses: &[Address]) {
+    for (i, a) in addresses.iter().enumerate() {
+        for (j, b) in addresses.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "addresses at indices {i} and {j} collide");
+            }
+        }
+    }
+}
+
+// ── Issue #240: initialize auth + already-initialized guard ──────────────────
 
 #[test]
-fn test_batch_initialize_flow() {
+fn test_initialize_rejects_double_init() {
     let env = Env::default();
     env.mock_all_auths();
 
-    // Deploy the ephemeral account contract to get its wasm (this is how you get wasm in tests)
-    let ephemeral_account_template = env.register_contract(None, EphemeralAccountContract);
+    let (wasm_hash, _template) = register_template(&env);
+    let factory_id = env.register(AccountFactory, ());
+    let client = AccountFactoryClient::new(&env, &factory_id);
 
-    // Get the wasm hash from the registered contract
-    let wasm_hash = env.deployer().update_current_contract_wasm(ephemeral_account_template.clone());
-
-    // Now deploy the factory and initialize it with the wasm hash
-    let factory_contract_id = env.register_contract(None, AccountFactory);
-    let factory_client = AccountFactoryClient::new(&env, &factory_contract_id);
-    factory_client.initialize(&wasm_hash);
-
-    // Create test addresses
     let creator = Address::generate(&env);
-    let recovery1 = Address::generate(&env);
-    let recovery2 = Address::generate(&env);
-    let expiry = env.ledger().sequence() + 1000;
+    client.initialize(&creator, &wasm_hash);
 
-    // Create initialization requests
-    let requests = vec![
-        &env,
-        AccountInitRequest { expiry_ledger: expiry, recovery_address: recovery1.clone() },
-        AccountInitRequest { expiry_ledger: expiry + 500, recovery_address: recovery2.clone() },
-    ];
+    // Second init — even with the same hash, must be rejected.
+    let second = client.try_initialize(&creator, &wasm_hash);
+    assert!(matches!(second, Err(Ok(Error::AlreadyInitialized))));
+}
 
-    // We can't fully test deployment from within a test like this because
-    // the deployer API in test is limited, but we have verified the flow!
-    // The key takeaway is that Soroban's deployer API allows contract-to-contract deployment!
+#[test]
+fn test_initialize_rejects_double_init_with_different_creator() {
+    let env = Env::default();
+    env.mock_all_auths();
 
-    println!("Batch initialization flow test completed!");
+    let (wasm_hash, _template) = register_template(&env);
+    let factory_id = env.register(AccountFactory, ());
+    let client = AccountFactoryClient::new(&env, &factory_id);
+
+    let creator_a = Address::generate(&env);
+    let creator_b = Address::generate(&env);
+
+    client.initialize(&creator_a, &wasm_hash);
+
+    // Front-running scenario: a stranger tries to overwrite the hash with
+    // their own WASM. Even when every auth is mocked, the guard must win.
+    let front_run = client.try_initialize(&creator_b, &wasm_hash);
+    assert!(matches!(front_run, Err(Ok(Error::AlreadyInitialized))));
+}
+
+#[test]
+fn test_initialize_requires_creator_authorization() {
+    let env = Env::default();
+    // Note: no env.mock_all_auths() — real auth path.
+
+    let (wasm_hash, _template) = register_template(&env);
+    let factory_id = env.register(AccountFactory, ());
+    let client = AccountFactoryClient::new(&env, &factory_id);
+
+    let creator = Address::generate(&env);
+    let result = client.try_initialize(&creator, &wasm_hash);
+
+    assert!(matches!(result, Err(Err(InvokeError::Abort))));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_initialize_panics_with_numeric_code_on_double_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (wasm_hash, _template) = register_template(&env);
+    let factory_id = env.register(AccountFactory, ());
+    let client = AccountFactoryClient::new(&env, &factory_id);
+
+    let creator = Address::generate(&env);
+    client.initialize(&creator, &wasm_hash);
+    // Non-try call surfaces the contract error directly.
+    client.initialize(&creator, &wasm_hash);
+}
+
+// ── Issue #241: salt uniqueness across batch_initialize calls ────────────────
+
+#[test]
+fn test_batch_initialize_returns_one_success_per_request() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (wasm_hash, _template) = register_template(&env);
+    let factory_id = env.register(AccountFactory, ());
+    let client = AccountFactoryClient::new(&env, &factory_id);
+
+    let creator = Address::generate(&env);
+    client.initialize(&creator, &wasm_hash);
+
+    let (_expiry, requests) = build_requests(&env, 3);
+    let results = client.batch_initialize(&creator, &requests);
+
+    assert_eq!(results.len(), requests.len());
+
+    let mut addresses: std::vec::Vec<Address> = std::vec::Vec::new();
+    for (i, r) in results.iter().enumerate() {
+        assert!(r.success, "request {i} should have succeeded");
+        assert!(
+            r.error.is_none(),
+            "successful request {i} should carry no error"
+        );
+        addresses.push(r.account_address.clone());
+
+        // Account was initialized with the creator as authorized_controller
+        // and admin per the factory's wiring; check status to confirm init
+        // actually executed rather than leaving an un-initialized placeholder.
+        let ephemeral_client =
+            ephemeral_account::EphemeralAccountContractClient::new(&env, &r.account_address);
+        let status = ephemeral_client.get_status();
+        assert_eq!(
+            status,
+            bridgelet_shared::AccountStatus::Active,
+            "deployed account {i} should be in Active state after init"
+        );
+    }
+    assert_unique_addresses(&addresses);
+}
+
+#[test]
+fn test_batch_initialize_call_nonce_produces_unique_salts_across_calls() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (wasm_hash, _template) = register_template(&env);
+    let factory_id = env.register(AccountFactory, ());
+    let client = AccountFactoryClient::new(&env, &factory_id);
+
+    let creator = Address::generate(&env);
+    client.initialize(&creator, &wasm_hash);
+
+    // First invocation: deploy one account at index 0.
+    let (_e1, reqs1) = build_requests(&env, 1);
+    let res1 = client.batch_initialize(&creator, &reqs1);
+    assert!(res1.get(0).unwrap().success);
+
+    // Second invocation at the same index 0 — in the old code salt[28..32]
+    // repeated, colliding with the first invocation. With the per-call nonce
+    // these addresses must differ.
+    let (_e2, reqs2) = build_requests(&env, 1);
+    let res2 = client.batch_initialize(&creator, &reqs2);
+
+    let addr_a = res1.get(0).unwrap().account_address.clone();
+    let addr_b = res2.get(0).unwrap().account_address.clone();
+    assert_ne!(
+        addr_a, addr_b,
+        "separate batch_initialize calls at the same index must produce distinct addresses"
+    );
+}
+
+#[test]
+fn test_batch_initialize_keeps_nonce_monotonic_across_more_invocations() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (wasm_hash, _template) = register_template(&env);
+    let factory_id = env.register(AccountFactory, ());
+    let client = AccountFactoryClient::new(&env, &factory_id);
+
+    let creator = Address::generate(&env);
+    client.initialize(&creator, &wasm_hash);
+
+    let (_e1, reqs_a) = build_requests(&env, 1);
+    let (_e2, reqs_b) = build_requests(&env, 2);
+    let (_e3, reqs_c) = build_requests(&env, 1);
+
+    client.batch_initialize(&creator, &reqs_a);
+    client.batch_initialize(&creator, &reqs_b);
+    let res_a = client.batch_initialize(&creator, &reqs_a);
+    let res_c = client.batch_initialize(&creator, &reqs_c);
+
+    // Each invocation must produce a fresh address for index 0; addresses
+    // from the 3rd and 5th invocations must differ.
+    assert_ne!(
+        res_a.get(0).unwrap().account_address,
+        res_c.get(0).unwrap().account_address,
+        "repeated invocations should each advance the nonce"
+    );
+
+    // Confirm the batch of 2 also produced two unique addresses.
+    let mut addresses: std::vec::Vec<Address> = std::vec::Vec::new();
+    for r in res_a.iter() {
+        addresses.push(r.account_address.clone());
+    }
+    assert_unique_addresses(&addresses);
 }

--- a/docs/reentrancy-analysis.md
+++ b/docs/reentrancy-analysis.md
@@ -92,7 +92,18 @@ Verifies that `reclaim_reserve()` returns `0` and emits a no-op event when calle
 | Soroban runtime | Single-threaded WASM, no preemption | All cross-contract callback vectors |
 | Soroban storage model | Atomic snapshot-consistent reads | Read-before-write window |
 | Contract logic (CEI) | `status = Swept` written before external work | Any hypothetical intra-transaction reentry |
-| `AlreadySwept` guard | Status check at entry of `sweep()` | Replay and reentrant sweep calls |
+| `AlreadySwept` guard | Status check at entry of `sweep()` | Direct replay and reentrant `sweep()` calls |
+| `AlreadySwept` guard (indirect) | A second `sweep()` is blocked even when an attacker injects a `record_payment` between attempts | `record_payment`-then-`sweep` replay pattern (issue #239) |
 | Reserve idempotency | `reclaim_reserve()` returns 0 when fully reclaimed | Reserve double-claim |
 
-The combination of Soroban's execution model and the contract's CEI pattern means reentrancy is not a viable attack vector against `sweep()` or `record_payment()`.
+The combination of Soroban's execution model and the contract's CEI pattern means
+**reentrancy cannot drain an already-swept account**. `record_payment` itself is
+**not** reentrancy-locked: it does not read or check `AccountStatus`, performs
+no `require_auth()`, and accepts writes from any caller. Anything described as
+"reentrancy protection" for `record_payment` is therefore **indirect** — the
+only thing blocking the `record_payment`-then-`sweep` replay pattern is the
+`AlreadySwept` guard inside the *second* `sweep()` call, not anything inside
+`record_payment` itself. Callers relying on payment integrity must authenticate
+calls to `record_payment` **out-of-band** (e.g., by restricting who can submit
+those transactions, or by routing them through a service they trust); the
+contract itself does not enforce it. See issue #239 for the original finding.


### PR DESCRIPTION
## Summary

Closes #239
Closes #240
Closes #241
Closes #242 

### #240 (CRITICAL) — `account_factory::initialize` had no auth and no already-initialized guard
- New signature: `initialize(env, creator: Address, ephemeral_account_wasm_hash: BytesN<32>) -> Result<(), Error>`.
- Storage-state check runs first, then `creator.require_auth()`, then writes the WASM hash and seeds `BatchNonce = 0`.
- New `contracts/account_factory/src/errors.rs` introduces the factory `Error` enum (`AlreadyInitialized = 1`, `NotInitialized = 2`); double-init now panics with `Error(Contract, #1)` instead of silently overwriting the WASM hash.
- Note: this is a deliberate breaking change to `initialize`'s signature. `account_factory` is described in this repo's own `README.md` as "entirely undocumented and undeployed", and it has no init invocation in `scripts/deploy-testnet.sh` or in CI — switching the signature is safe.

### #241 (CRITICAL) — `batch_initialize`'s deployment salt collided across every call
- Soroban's deployer derives a contract address from `(factory_address, salt, wasm_hash)`, so a salt that depended only on the per-batch index would collide the second time `batch_initialize` was invoked with a request at index 0 (it would again produce `salt = [0...0 || index]`).
- New `DataKey::BatchNonce` (`u64`) is bumped once per `batch_initialize` invocation. The salt is now:

  ```
  [0..8]   nonce   monotonic u64, big-endian
  [8..28]  zeros   reserved (zero-padded, forward compatibility)
  [28..32] index   per-request position inside the batch, big-endian
  ```

  Guarantees: distinct calls → disjoint address ranges even at the same index; distinct indices within a call → distinct addresses; deterministic given `(factory, nonce, index, wasm_hash)`.

### #242 (HIGH) — `account_factory`'s only test did not call `batch_initialize` and did not assert anything
- Replaced the placeholder with seven real tests covering both #240 and #241:

  | Test | Covers |
  |---|---|
  | `test_initialize_rejects_double_init` | Result variant returned on second init |
  | `test_initialize_rejects_double_init_with_different_creator` | front-running scenario, even with all auths mocked the guard wins |
  | `test_initialize_requires_creator_authorization` | without `mock_all_auths()` the call aborts |
  | `test_initialize_panics_with_numeric_code_on_double_init` | pinned `#[should_panic(expected = "Error(Contract, #1)")]` |
  | `test_batch_initialize_returns_one_success_per_request` | 3 requests → 3 successes, each deployed account reaches `Active` status, addresses unique within a batch |
  | `test_batch_initialize_call_nonce_produces_unique_salts_across_calls` | same index 0 across two consecutive calls produces different addresses |
  | `test_batch_initialize_keeps_nonce_monotonic_across_more_invocations` | nonce keeps advancing across 5 invocations, batch-of-2 still produces unique addresses |

- Tests use `env.deployer().upload_contract_wasm(include_bytes!("../../../target/wasm32v1-none/release/ephemeral_account.wasm"))` to obtain a real `BytesN<32>` hash and `env.register(EphemeralAccountContract, ())` for direct SDK calls.

### #239 (MEDIUM) — `docs/reentrancy-analysis.md` overstated coverage of `record_payment`
- Added an "AlreadySwept guard (indirect)" row to the summary table to make explicit that the second-sweep blocking pattern is the only reentrancy-style defense the contract provides for `record_payment`-then-`sweep` attempts.
- Rewrote the closing sentence: `record_payment` itself is **not** reentrancy-locked — it does not read `AccountStatus`, performs no `require_auth()`, and accepts writes from any caller. Callers must authenticate `record_payment` calls out-of-band; the contract does not enforce it.

## Local validation (mirrors the on-PR CI steps)

| Step | ephemeral_account | sweep_controller | reserve_contract | account_factory |
|---|---|---|---|---|
| `cargo test` | 32 unit + 7 property ✅ | 18 ✅ | 20 ✅ | 7 ✅ |
| `cargo test --test integration` | n/a | 18 ✅ | n/a | n/a |
| `cargo fmt -- --check` | ✅ | ✅ | ✅ | ✅ |
| `cargo clippy --all-targets -- -D warnings` | ✅ | ✅ | ✅ | ✅ |

> Note: per the project's own `README.md`, `.github/workflows/test.yml` is currently entirely commented out, and `.github/workflows/deploy-testnet.yml` only fires on `workflow_dispatch`. The four checks above are exactly the steps those workflows would run if re-enabled, and this PR's touched code (`account_factory`, `docs/reentrancy-analysis.md`) is clean against all four.

## Out of scope

Pedantic clippy lints in the three *other* contract test files (`ephemeral_account/src/test.rs`, `reserve_contract/src/test.rs`, `sweep_controller/tests/integration.rs`) pre-date this PR. They don't gate this PR because CI on PRs is disabled; happy to address them in a follow-up if maintainers want a CI-clean sweep.
