### PR TITLE
feat: shared events, sweep replay protection, storage audit, and sdk pin docs

### DIFF
--- a/contracts/ephemeral_account/src/events.rs
+++ b/contracts/ephemeral_account/src/events.rs
@@ -1,51 +1,12 @@
+// Issue #40: event schemas are defined once in the shared crate and re-exported
+// here so existing `events::AccountCreated` (etc.) references keep working.
+pub use bridgelet_shared::{
+    AccountCreated, AccountExpired, MultiPaymentReceived, PaymentReceived, ReserveReclaimed,
+    SweepExecutedMulti,
+};
+
 use bridgelet_shared::Payment;
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AccountCreated {
-    pub creator: Address,
-    pub expiry_ledger: u32,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PaymentReceived {
-    pub amount: i128,
-    pub asset: Address,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SweepExecutedMulti {
-    pub destination: Address,
-    pub payments: Vec<Payment>,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MultiPaymentReceived {
-    pub asset: Address,
-    pub amount: i128,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AccountExpired {
-    pub recovery_address: Address,
-    pub amount_returned: i128,
-    pub reserve_amount: i128,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReserveReclaimed {
-    pub destination: Address,
-    pub amount: i128,
-    pub sweep_id: u64,
-    pub fully_reclaimed: bool,
-    pub remaining_reserve: i128,
-}
+use soroban_sdk::{symbol_short, Address, Env, Vec};
 
 pub fn emit_account_created(env: &Env, creator: Address, expiry_ledger: u32) {
     let event = AccountCreated {

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -1,0 +1,57 @@
+use crate::types::Payment;
+use soroban_sdk::{contracttype, Address, Vec};
+
+/// Issue #40: contract event definitions live in the shared crate so the SDK
+/// and every contract reference identical event schemas.
+
+/// Emitted when an ephemeral account is created.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountCreated {
+    pub creator: Address,
+    pub expiry_ledger: u32,
+}
+
+/// Emitted when a single payment is received by an ephemeral account.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaymentReceived {
+    pub amount: i128,
+    pub asset: Address,
+}
+
+/// Emitted when an account is swept, carrying every recorded payment.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SweepExecutedMulti {
+    pub destination: Address,
+    pub payments: Vec<Payment>,
+}
+
+/// Emitted when a payment is received while multiple payments are tracked.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiPaymentReceived {
+    pub asset: Address,
+    pub amount: i128,
+}
+
+/// Emitted when an expired account returns funds to its recovery address.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountExpired {
+    pub recovery_address: Address,
+    pub amount_returned: i128,
+    pub reserve_amount: i128,
+}
+
+/// Emitted when reserve funds are reclaimed after a sweep.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReserveReclaimed {
+    pub destination: Address,
+    pub amount: i128,
+    pub sweep_id: u64,
+    pub fully_reclaimed: bool,
+    pub remaining_reserve: i128,
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,7 +1,12 @@
 #![no_std]
 
+mod events;
 mod interfaces;
 mod types;
 
+pub use events::{
+    AccountCreated, AccountExpired, MultiPaymentReceived, PaymentReceived, ReserveReclaimed,
+    SweepExecutedMulti,
+};
 pub use interfaces::{EphemeralAccountInterface, SweepControllerInterface};
 pub use types::{AccountInfo, AccountInitRequest, AccountInitResult, AccountStatus, Payment};

--- a/contracts/sweep_controller/src/authorization.rs
+++ b/contracts/sweep_controller/src/authorization.rs
@@ -4,24 +4,39 @@ use soroban_sdk::{xdr::ToXdr, Address, BytesN, Env};
 
 /// Construct the message to be signed for sweep authorization
 ///
-/// Message format: hash(destination + nonce + contract_id)
+/// Message format: hash(account + destination + nonce + contract_id)
+///
+/// Binding the ephemeral `account` into the signed message ensures a captured
+/// signature cannot be replayed against a different account, while the `nonce`
+/// prevents replay of the same authorization at a later time.
 ///
 /// # Arguments
 /// * `env` - Soroban environment
+/// * `account` - Ephemeral account the sweep authorizes
 /// * `destination` - Destination wallet address
 /// * `contract_id` - The sweep controller contract address
 ///
 /// # Returns
 /// BytesN<32> containing the hash of the message components
-fn construct_sweep_message(env: &Env, destination: &Address, contract_id: &Address) -> BytesN<32> {
+fn construct_sweep_message(
+    env: &Env,
+    account: &Address,
+    destination: &Address,
+    contract_id: &Address,
+) -> BytesN<32> {
     // Get current nonce
     let nonce = storage::get_sweep_nonce(env);
 
     // Construct the message by concatenating:
+    // - account (serialized as bytes)
     // - destination (serialized as bytes)
     // - nonce (as u64, 8 bytes)
     // - contract_id (serialized as bytes)
     let mut message = soroban_sdk::Bytes::new(env);
+
+    // Add ephemeral account address bytes
+    let account_bytes = account.to_xdr(env);
+    message.append(&account_bytes);
 
     // Add destination address bytes
     let dest_bytes = destination.to_xdr(env);
@@ -52,7 +67,7 @@ fn construct_sweep_message(env: &Env, destination: &Address, contract_id: &Addre
 ///
 /// # Arguments
 /// * `env` - Soroban environment
-/// * `account` - Ephemeral account address (used as context)
+/// * `account` - Ephemeral account address (bound into the signed message)
 /// * `destination` - Destination wallet address
 /// * `signature` - Ed25519 signature (64 bytes)
 ///
@@ -60,7 +75,7 @@ fn construct_sweep_message(env: &Env, destination: &Address, contract_id: &Addre
 /// Ok(()) if signature is valid, Error otherwise
 pub fn verify_sweep_auth(
     env: &Env,
-    _account: &Address,
+    account: &Address,
     destination: &Address,
     signature: &BytesN<64>,
 ) -> Result<(), Error> {
@@ -72,7 +87,7 @@ pub fn verify_sweep_auth(
     let contract_id = env.current_contract_address();
 
     // Construct the message that should have been signed
-    let message = construct_sweep_message(env, destination, &contract_id);
+    let message = construct_sweep_message(env, account, destination, &contract_id);
 
     // Verify the Ed25519 signature
     env.crypto()

--- a/contracts/sweep_controller/src/storage.rs
+++ b/contracts/sweep_controller/src/storage.rs
@@ -1,6 +1,22 @@
+//! Storage key audit (Issue #25).
+//!
+//! All keys live in the [`DataKey`] enum and are read/written exclusively
+//! through `env.storage().instance()`. Soroban scopes instance storage to the
+//! individual deployed contract instance, so keys are already namespaced by
+//! the contract's own address at the host level — two deployments of this
+//! contract cannot collide, and no manual address prefix is required.
+//!
+//! Within a single instance, every `#[contracttype]` enum variant serialises
+//! to a distinct key. The variants below are unique and non-overlapping, so
+//! there are no intra-contract collisions either.
+
 use soroban_sdk::{contracttype, Address, BytesN, Env};
 
-/// Data keys for contract storage
+/// Data keys for contract storage.
+///
+/// Each variant is a distinct instance-storage key. Instance storage is
+/// automatically namespaced per deployed contract instance by the Soroban
+/// host, preventing cross-instance collisions.
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {

--- a/docs/DEPENDENCY_PINNING.md
+++ b/docs/DEPENDENCY_PINNING.md
@@ -1,0 +1,56 @@
+# Dependency Pinning: `soroban-sdk`
+
+Issue #42.
+
+## Policy
+
+Every workspace member builds against the **same** `soroban-sdk` version.
+The version is pinned once, at the workspace root, and members inherit it —
+no member declares its own range.
+
+- Root `Cargo.toml`:
+
+  ```toml
+  [workspace.dependencies]
+  soroban-sdk = "22.0.0"
+  ```
+
+- Each contract (`shared`, `ephemeral_account`, `sweep_controller`,
+  `reserve_contract`, `account_factory`):
+
+  ```toml
+  [dependencies]
+  soroban-sdk = { workspace = true }
+
+  [dev-dependencies]
+  soroban-sdk = { workspace = true, features = ["testutils"] }
+  ```
+
+Two dependencies live outside the workspace inheritance and are pinned
+directly to the same version, so they must be bumped together with the root:
+
+- `contracts/sweep_controller/Cargo.toml` → `soroban-token-sdk = "22.0.0"`
+- `tools/sweep-signer/Cargo.toml` → `soroban-sdk = "22.0.0"` (standalone
+  workspace; its `Address::to_xdr()` output must match the deployed contracts,
+  so it has to track the same version)
+
+## No open ranges
+
+The current pin is `22.0.0`. Do not widen it to a range (`>=`, `^` with a
+looser floor, `*`, etc.): a silent minor bump can change host behaviour,
+generated event schemas, or XDR serialization between the contract and the
+off-chain signer.
+
+## Upgrade process
+
+Bumping `soroban-sdk` is a coordinated change, not a routine dependency update:
+
+1. Change `soroban-sdk` in the root `[workspace.dependencies]`.
+2. Change `soroban-token-sdk` (sweep_controller) and the `tools/sweep-signer`
+   pin to the matching version in the same commit.
+3. `cargo update -p soroban-sdk` and commit the updated `Cargo.lock`.
+4. `stellar contract build` and run the full test suite locally.
+5. **Deploy to testnet and exercise the full sweep flow end to end** before
+   promoting the bump — verify signatures produced by `tools/sweep-signer`
+   still verify on-chain, since XDR serialization is version-sensitive.
+6. Only then merge and roll out to mainnet.

--- a/docs/SIGNATURE_FORMAT.md
+++ b/docs/SIGNATURE_FORMAT.md
@@ -4,7 +4,9 @@
 
 The sweep controller uses **Ed25519 signature verification** to ensure only authorized parties can initiate sweeps. This document describes the exact message format that must be signed off-chain and provides implementation examples.
 
-> **Correction:** an earlier version of this document included a `timestamp` component in the signed message, in every example below (TypeScript, Python, Rust) and in the Security Considerations and Troubleshooting sections. That was never accurate. The deployed contract — `contracts/sweep_controller/src/authorization.rs::construct_sweep_message()` — does not read, generate, or check a timestamp anywhere. It uses exactly **three** components. Every example in this revision has been corrected to match the real code; if you signed anything using the old examples, those signatures will not verify on-chain.
+> **Correction:** an earlier version of this document included a `timestamp` component in the signed message. That was never accurate — the deployed contract does not read, generate, or check a timestamp anywhere.
+>
+> **Issue #29 update:** the signed message now also binds the **ephemeral account** address as its first component. Without it, a captured signature (same nonce, same destination) could be replayed against a *different* ephemeral account. The deployed contract — `contracts/sweep_controller/src/authorization.rs::construct_sweep_message()` — uses exactly **four** components: account, destination, nonce, and contract id. If you signed anything using an older format, those signatures will not verify on-chain.
 
 ## Message Construction
 
@@ -12,6 +14,7 @@ The message to be signed is constructed as follows:
 
 ```
 message = SHA256(
+    account_address_xdr     ||
     destination_address_xdr ||
     sweep_nonce_be_u64      ||
     contract_id_xdr
@@ -20,24 +23,29 @@ message = SHA256(
 
 ### Components
 
-1. **destination_address_xdr** (variable length)
+1. **account_address_xdr** (variable length)
+   - The ephemeral account address the sweep authorizes
+   - Serialized as XDR bytes using `soroban_sdk::Address::to_xdr(&env)`
+   - Binds the signature to one specific account so it cannot be replayed against another
+
+2. **destination_address_xdr** (variable length)
    - The wallet address where funds will be swept to
    - Serialized as XDR bytes using `soroban_sdk::Address::to_xdr(&env)` — the Soroban SDK's own serialization, not a hand-rolled encoding of the `G...`/`C...` strkey
    - Length varies by address type; don't assume a fixed size
 
-2. **sweep_nonce** (8 bytes, big-endian)
+3. **sweep_nonce** (8 bytes, big-endian)
    - Unsigned 64-bit integer
    - Starts at 0 for the first sweep (set at `initialize()`)
    - Increments by 1 after each successful sweep authorization
    - Prevents replay attacks by invalidating previous signatures
    - **The contract always verifies against its own current on-chain nonce.** Query it with `SweepController::get_nonce()` before signing — don't rely on a locally-tracked counter, which can drift if a sweep fails partway or another process triggers one.
 
-3. **contract_id** (variable length)
+4. **contract_id** (variable length)
    - The address of the sweep controller contract itself (`env.current_contract_address()`)
    - Serialized as XDR bytes the same way as the destination
    - Binds the signature to a specific contract deployment — a signature valid on one `SweepController` instance will not verify on another
 
-There is no timestamp, expiry, or any fourth component. The concatenated bytes above are hashed exactly once with SHA-256, and that 32-byte digest is what gets Ed25519-signed.
+There is no timestamp or expiry component. The concatenated bytes above are hashed exactly once with SHA-256, and that 32-byte digest is what gets Ed25519-signed.
 
 ### Hash Function
 
@@ -71,6 +79,7 @@ import * as crypto from 'crypto';
 import * as ed25519 from '@noble/ed25519';
 
 interface SweepAuthParams {
+  accountXdr: Buffer;       // Address::to_xdr() bytes — see note above
   destinationXdr: Buffer;   // Address::to_xdr() bytes — see note above
   contractIdXdr: Buffer;    // Address::to_xdr() bytes — see note above
   nonce: bigint;            // current on-chain nonce; query get_nonce() first
@@ -86,6 +95,7 @@ async function generateSweepSignature(
 
   // Concatenate all components — destination, nonce, contract_id, in that order
   const message = Buffer.concat([
+    params.accountXdr,
     params.destinationXdr,
     nonceBuffer,
     params.contractIdXdr,
@@ -110,6 +120,7 @@ async function verifySweepSignature(
   nonceBuffer.writeBigUInt64BE(params.nonce, 0);
 
   const message = Buffer.concat([
+    params.accountXdr,
     params.destinationXdr,
     nonceBuffer,
     params.contractIdXdr,
@@ -125,6 +136,7 @@ const privateKeyHex = 'your-private-key-hex';
 const privateKey = Buffer.from(privateKeyHex, 'hex');
 
 const params: SweepAuthParams = {
+  accountXdr: Buffer.from('...', 'base64'),     // properly XDR-encoded, see note above
   destinationXdr: Buffer.from('...', 'base64'), // properly XDR-encoded, see note above
   contractIdXdr: Buffer.from('...', 'base64'),  // properly XDR-encoded, see note above
   nonce: 0n,
@@ -150,6 +162,7 @@ class SweepAuthSigner:
 
     def construct_message(
         self,
+        account_xdr: bytes,
         destination_xdr: bytes,
         contract_id_xdr: bytes,
         nonce: int,
@@ -157,19 +170,20 @@ class SweepAuthSigner:
         """Construct the message to be signed."""
         nonce_bytes = struct.pack('>Q', nonce)  # Big-endian unsigned 64-bit
 
-        # Concatenate: destination, nonce, contract_id — no timestamp
-        message = destination_xdr + nonce_bytes + contract_id_xdr
+        # Concatenate: account, destination, nonce, contract_id — no timestamp
+        message = account_xdr + destination_xdr + nonce_bytes + contract_id_xdr
 
         return message
 
     def generate_signature(
         self,
+        account_xdr: bytes,
         destination_xdr: bytes,
         contract_id_xdr: bytes,
         nonce: int,
     ) -> bytes:
         """Generate Ed25519 signature for sweep authorization."""
-        message = self.construct_message(destination_xdr, contract_id_xdr, nonce)
+        message = self.construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce)
 
         # Hash the message with SHA-256
         message_hash = hashlib.sha256(message).digest()
@@ -181,13 +195,14 @@ class SweepAuthSigner:
 
     def verify_signature(
         self,
+        account_xdr: bytes,
         destination_xdr: bytes,
         contract_id_xdr: bytes,
         nonce: int,
         signature: bytes,
     ) -> bool:
         """Verify sweep authorization signature."""
-        message = self.construct_message(destination_xdr, contract_id_xdr, nonce)
+        message = self.construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce)
         message_hash = hashlib.sha256(message).digest()
 
         try:
@@ -201,15 +216,16 @@ class SweepAuthSigner:
 private_key_hex = 'your-private-key-hex'
 signer = SweepAuthSigner(private_key_hex)
 
+account_xdr = b'...'      # XDR-encoded ephemeral account address, see note above
 destination_xdr = b'...'  # XDR-encoded destination address, see note above
 contract_id_xdr = b'...'  # XDR-encoded contract ID, see note above
 nonce = 0  # query SweepController.get_nonce() first — don't hardcode in real use
 
-signature = signer.generate_signature(destination_xdr, contract_id_xdr, nonce)
+signature = signer.generate_signature(account_xdr, destination_xdr, contract_id_xdr, nonce)
 print('Signature (hex):', signature.hex())
 
 # Verify
-is_valid = signer.verify_signature(destination_xdr, contract_id_xdr, nonce, signature)
+is_valid = signer.verify_signature(account_xdr, destination_xdr, contract_id_xdr, nonce, signature)
 print(f'Signature valid: {is_valid}')
 ```
 
@@ -230,11 +246,13 @@ impl SweepAuthSigner {
     }
 
     pub fn construct_message(
+        account_xdr: &[u8],
         destination_xdr: &[u8],
         contract_id_xdr: &[u8],
         nonce: u64,
     ) -> Vec<u8> {
         let mut message = Vec::new();
+        message.extend_from_slice(account_xdr);
         message.extend_from_slice(destination_xdr);
         message.extend_from_slice(&nonce.to_be_bytes());
         message.extend_from_slice(contract_id_xdr);
@@ -243,11 +261,12 @@ impl SweepAuthSigner {
 
     pub fn generate_signature(
         &self,
+        account_xdr: &[u8],
         destination_xdr: &[u8],
         contract_id_xdr: &[u8],
         nonce: u64,
     ) -> Vec<u8> {
-        let message = Self::construct_message(destination_xdr, contract_id_xdr, nonce);
+        let message = Self::construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce);
 
         let mut hasher = Sha256::new();
         hasher.update(&message);
@@ -259,12 +278,13 @@ impl SweepAuthSigner {
 
     pub fn verify_signature(
         &self,
+        account_xdr: &[u8],
         destination_xdr: &[u8],
         contract_id_xdr: &[u8],
         nonce: u64,
         signature_bytes: &[u8; 64],
     ) -> bool {
-        let message = Self::construct_message(destination_xdr, contract_id_xdr, nonce);
+        let message = Self::construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce);
 
         let mut hasher = Sha256::new();
         hasher.update(&message);
@@ -279,18 +299,19 @@ impl SweepAuthSigner {
 let private_key_bytes = [0u8; 32]; // Load from secure storage
 let signer = SweepAuthSigner::new(&private_key_bytes);
 
+let account_xdr = b"...";     // XDR-encoded ephemeral account, see note above
 let destination_xdr = b"..."; // XDR-encoded destination, see note above
 let contract_id_xdr = b"..."; // XDR-encoded contract ID, see note above
 let nonce = 0u64; // query get_nonce() first — don't hardcode in real use
 
-let signature = signer.generate_signature(destination_xdr, contract_id_xdr, nonce);
+let signature = signer.generate_signature(account_xdr, destination_xdr, contract_id_xdr, nonce);
 println!("Signature: {}", hex::encode(&signature));
 ```
 
 ### Reference Implementation
 
 Rather than any of the illustrative snippets above, the tool actually checked against the real `soroban-sdk` XDR serialization lives at `tools/sweep-signer/` in this repo. It's a small Rust CLI that:
-- Takes a Stellar secret key, destination address, contract ID, and nonce
+- Takes a Stellar secret key, ephemeral account address, destination address, contract ID, and nonce
 - Uses `soroban_sdk::Address::to_xdr()` directly (via a local, network-free `Env`) to guarantee byte-identical serialization to what the deployed contract computes
 - Outputs the hex signature ready to pass to `execute_sweep()`
 
@@ -304,7 +325,7 @@ The off-chain system should:
 2. **Query current contract state** to get:
    - Current nonce, via `SweepController::get_nonce()`
    - Contract ID (the deployed `SweepController` address)
-3. **Construct message** using the format above (destination, nonce, contract_id — no timestamp)
+3. **Construct message** using the format above (account, destination, nonce, contract_id — no timestamp)
 4. **Sign message** with the authorized signer's private key
 5. **Call `execute_sweep` contract function** with the generated signature
 
@@ -320,6 +341,7 @@ The off-chain system should:
 ### Signature Validity
 
 - Signatures are **bound to a specific contract deployment** via contract_id
+- Signatures are **bound to a specific ephemeral account** via the account component, so a captured signature cannot be replayed against a different account
 - Signatures cannot be used against a different deployment
 - Signatures do **not** expire based on time — there is no timestamp or expiry window in this scheme. The only thing that invalidates a previously-issued, not-yet-used signature is the nonce advancing (i.e. another sweep happening first). If you need time-bounded authorization, that would have to be built as a new feature — it does not exist today.
 

--- a/docs/STORAGE_AUDIT.md
+++ b/docs/STORAGE_AUDIT.md
@@ -1,0 +1,45 @@
+# SweepController Storage Key Audit
+
+Issue #25.
+
+## Scope
+
+Review `contracts/sweep_controller/src/storage.rs` for storage-key naming and
+confirm there is no risk of key collisions — either between multiple deployed
+instances of the contract, or between keys within a single instance.
+
+## Keys
+
+All keys are variants of a single `#[contracttype]` enum, `DataKey`:
+
+| Variant                 | Value type    | Access        |
+| ----------------------- | ------------- | ------------- |
+| `AuthorizedSigner`      | `BytesN<32>`  | instance      |
+| `SweepNonce`            | `u64`         | instance      |
+| `AuthorizedDestination` | `Address`     | instance      |
+| `Creator`               | `Address`     | instance      |
+
+Every read and write goes through `env.storage().instance()`.
+
+## Findings
+
+### Cross-instance collisions — not possible
+
+Soroban scopes instance (and persistent/temporary) storage to the individual
+deployed contract instance. The host keys every entry by the contract's own
+address, so two separate deployments of `SweepController` have completely
+disjoint storage. A manual contract-address prefix on the keys would be
+redundant — the isolation is provided by the platform, not by the key name.
+
+### Intra-instance collisions — not possible
+
+Within one instance, each `DataKey` enum variant serialises to a distinct
+key. The four variants are unique and carry no overlapping payload, so no two
+logical values map to the same key.
+
+## Conclusion
+
+No changes to the key layout are required. The audit is recorded inline as
+module-level rustdoc in `storage.rs` so the reasoning stays next to the code.
+If future keys are added, keep them as distinct `DataKey` variants (rather than
+raw symbols/strings) to preserve this guarantee.

--- a/tools/sweep-signer/src/main.rs
+++ b/tools/sweep-signer/src/main.rs
@@ -7,13 +7,13 @@
 //!         sweep-signer pubkey --signer-seed-hex <64 hex chars>
 //!
 //!   2. Per sweep, once deployed: produce the signature for execute_sweep().
-//!         sweep-signer sign --contract-id ... --destination ... --nonce ... --signer-seed-hex ...
+//!         sweep-signer sign --contract-id ... --account ... --destination ... --nonce ... --signer-seed-hex ...
 //!
 //! Message format (matches contracts/sweep_controller/src/authorization.rs
 //! exactly - NOT the timestamp-including format that was in the old
 //! docs/SIGNATURE_FORMAT.md before it was corrected):
 //!
-//!   message = SHA256( destination.to_xdr() || nonce_be_u64(8 bytes) || contract_id.to_xdr() )
+//!   message = SHA256( account.to_xdr() || destination.to_xdr() || nonce_be_u64(8 bytes) || contract_id.to_xdr() )
 //!   signature = Ed25519_sign(message, signer_private_key)
 //!
 //! Accepts the signing key as EITHER:
@@ -61,6 +61,12 @@ struct SignArgs {
     /// SweepController contract ID (C... address)
     #[arg(long)]
     contract_id: String,
+
+    /// Ephemeral account address the sweep authorizes (C... address). Bound
+    /// into the signed message so a captured signature cannot be replayed
+    /// against a different account.
+    #[arg(long)]
+    account: String,
 
     /// Destination wallet address funds will be swept to (G... address)
     #[arg(long)]
@@ -140,10 +146,12 @@ fn main() {
             // Address::to_xdr() encoding, guaranteed to match on-chain.
             let env = Env::default();
 
+            let account = Address::from_str(&env, &args.account);
             let destination = Address::from_str(&env, &args.destination);
             let contract_id = Address::from_str(&env, &args.contract_id);
 
             let mut message = Bytes::new(&env);
+            message.append(&account.to_xdr(&env));
             message.append(&destination.to_xdr(&env));
 
             for shift in (0..8).rev() {


### PR DESCRIPTION
Resolves four assigned issues in one branch.

## #40 — Define contract events in the shared crate
Moves the event struct definitions (`AccountCreated`, `PaymentReceived`, `SweepExecutedMulti`, `MultiPaymentReceived`, `AccountExpired`, `ReserveReclaimed`) into a new `contracts/shared/src/events.rs` and re-exports them. `ephemeral_account` keeps its `emit_*` helpers but now references the shared schemas, so every crate uses identical event definitions. Type names are unchanged, so the on-chain event schemas are byte-identical.

## #29 — Replay protection for sweep authorization
The signed sweep message already bound the nonce and contract id; it did **not** bind the ephemeral account, so a captured signature (same nonce + destination) could be replayed against a *different* account before the first sweep. `construct_sweep_message` now includes the account as its first component, and `verify_sweep_auth` uses it. `tools/sweep-signer` and `docs/SIGNATURE_FORMAT.md` are updated to the new four-component format.

## #25 — Storage key collision audit (SweepController)
Audited `sweep_controller/src/storage.rs`. All keys use `env.storage().instance()`, which the Soroban host already namespaces per deployed contract instance, and every `DataKey` variant is distinct — so there are no cross-instance or intra-instance collisions. Findings recorded as module rustdoc plus `docs/STORAGE_AUDIT.md`; no key-layout change required.

## #42 — Pin soroban-sdk to 22.0.0
Verified every `Cargo.toml` pins `22.0.0` (centralised via `[workspace.dependencies]`, with `soroban-token-sdk` and `tools/sweep-signer` pinned to match). Documented the pin policy and the test-on-testnet-before-bumping upgrade process in `docs/DEPENDENCY_PINNING.md`.

closes #141
closes #143
closes #153
closes #157
