### PR TITLE
feat: shared event schemas, sweep replay protection, storage audit, sdk pin docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ members = [
     "contracts/account_factory",
 ]
 
-# Issue #41: centralise the soroban-sdk version pin for every workspace member.
+# Issues #41 / #42: soroban-sdk is pinned to 22.0.0 in exactly one place — here.
+# Every workspace member inherits it via `soroban-sdk = { workspace = true }`,
+# so no contract declares its own version. See docs/soroban-sdk-version-policy.md
+# for the upgrade process (bump here only, then verify on testnet before merge).
 [workspace.dependencies]
 soroban-sdk = "22.0.0"
 

--- a/contracts/ephemeral_account/src/events.rs
+++ b/contracts/ephemeral_account/src/events.rs
@@ -1,51 +1,10 @@
-use bridgelet_shared::Payment;
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AccountCreated {
-    pub creator: Address,
-    pub expiry_ledger: u32,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PaymentReceived {
-    pub amount: i128,
-    pub asset: Address,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SweepExecutedMulti {
-    pub destination: Address,
-    pub payments: Vec<Payment>,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MultiPaymentReceived {
-    pub asset: Address,
-    pub amount: i128,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AccountExpired {
-    pub recovery_address: Address,
-    pub amount_returned: i128,
-    pub reserve_amount: i128,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ReserveReclaimed {
-    pub destination: Address,
-    pub amount: i128,
-    pub sweep_id: u64,
-    pub fully_reclaimed: bool,
-    pub remaining_reserve: i128,
-}
+// Issue #40: event schemas now live in the shared crate so the SDK and every
+// contract use identical definitions. This module keeps the thin emit_* helpers.
+use bridgelet_shared::{
+    AccountCreated, AccountExpired, MultiPaymentReceived, Payment, PaymentReceived,
+    ReserveReclaimed, SweepExecutedMulti,
+};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
 
 pub fn emit_account_created(env: &Env, creator: Address, expiry_ledger: u32) {
     let event = AccountCreated {

--- a/contracts/ephemeral_account/src/lib.rs
+++ b/contracts/ephemeral_account/src/lib.rs
@@ -8,12 +8,11 @@ mod test;
 
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
 
-pub use bridgelet_shared::{AccountInfo, AccountStatus, EphemeralAccountInterface, Payment};
-pub use errors::Error;
-pub use events::{
-    AccountCreated, AccountExpired, MultiPaymentReceived, PaymentReceived, ReserveReclaimed,
-    SweepExecutedMulti,
+pub use bridgelet_shared::{
+    AccountCreated, AccountExpired, AccountInfo, AccountStatus, EphemeralAccountInterface,
+    MultiPaymentReceived, Payment, PaymentReceived, ReserveReclaimed, SweepExecutedMulti,
 };
+pub use errors::Error;
 pub use storage::DataKey;
 
 const BASE_RESERVE_STROOPS: i128 = 1_000_000_000;

--- a/contracts/ephemeral_account/src/storage.rs
+++ b/contracts/ephemeral_account/src/storage.rs
@@ -1,5 +1,4 @@
-use crate::events::ReserveReclaimed;
-use bridgelet_shared::{AccountStatus, Payment};
+use bridgelet_shared::{AccountStatus, Payment, ReserveReclaimed};
 use soroban_sdk::{contracttype, Address, Env, Map};
 
 #[contracttype]

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -1,0 +1,54 @@
+//! Issue #40: Shared contract event schemas.
+//!
+//! Event struct definitions live here so the SDK and every contract share one
+//! identical schema. Contracts import these types and keep their own thin
+//! `emit_*` helpers that publish them.
+
+use crate::types::Payment;
+use soroban_sdk::{contracttype, Address, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountCreated {
+    pub creator: Address,
+    pub expiry_ledger: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaymentReceived {
+    pub amount: i128,
+    pub asset: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SweepExecutedMulti {
+    pub destination: Address,
+    pub payments: Vec<Payment>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiPaymentReceived {
+    pub asset: Address,
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountExpired {
+    pub recovery_address: Address,
+    pub amount_returned: i128,
+    pub reserve_amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReserveReclaimed {
+    pub destination: Address,
+    pub amount: i128,
+    pub sweep_id: u64,
+    pub fully_reclaimed: bool,
+    pub remaining_reserve: i128,
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,7 +1,12 @@
 #![no_std]
 
+mod events;
 mod interfaces;
 mod types;
 
+pub use events::{
+    AccountCreated, AccountExpired, MultiPaymentReceived, PaymentReceived, ReserveReclaimed,
+    SweepExecutedMulti,
+};
 pub use interfaces::{EphemeralAccountInterface, SweepControllerInterface};
 pub use types::{AccountInfo, AccountInitRequest, AccountInitResult, AccountStatus, Payment};

--- a/contracts/sweep_controller/src/authorization.rs
+++ b/contracts/sweep_controller/src/authorization.rs
@@ -4,24 +4,41 @@ use soroban_sdk::{xdr::ToXdr, Address, BytesN, Env};
 
 /// Construct the message to be signed for sweep authorization
 ///
-/// Message format: hash(destination + nonce + contract_id)
+/// Message format: hash(account + destination + nonce + contract_id)
+///
+/// Binding the ephemeral `account` into the signed payload (alongside the
+/// per-controller `nonce` and the `contract_id`) provides replay protection:
+/// a captured signature cannot be replayed against a different ephemeral
+/// account, a different destination, a different controller, or at a later
+/// time once the nonce has advanced. (#29)
 ///
 /// # Arguments
 /// * `env` - Soroban environment
+/// * `account` - Ephemeral account the sweep authorizes funds to leave
 /// * `destination` - Destination wallet address
 /// * `contract_id` - The sweep controller contract address
 ///
 /// # Returns
 /// BytesN<32> containing the hash of the message components
-fn construct_sweep_message(env: &Env, destination: &Address, contract_id: &Address) -> BytesN<32> {
+fn construct_sweep_message(
+    env: &Env,
+    account: &Address,
+    destination: &Address,
+    contract_id: &Address,
+) -> BytesN<32> {
     // Get current nonce
     let nonce = storage::get_sweep_nonce(env);
 
     // Construct the message by concatenating:
+    // - account (serialized as bytes)
     // - destination (serialized as bytes)
     // - nonce (as u64, 8 bytes)
     // - contract_id (serialized as bytes)
     let mut message = soroban_sdk::Bytes::new(env);
+
+    // Add ephemeral account address bytes so the signature is bound to it
+    let account_bytes = account.to_xdr(env);
+    message.append(&account_bytes);
 
     // Add destination address bytes
     let dest_bytes = destination.to_xdr(env);
@@ -60,7 +77,7 @@ fn construct_sweep_message(env: &Env, destination: &Address, contract_id: &Addre
 /// Ok(()) if signature is valid, Error otherwise
 pub fn verify_sweep_auth(
     env: &Env,
-    _account: &Address,
+    account: &Address,
     destination: &Address,
     signature: &BytesN<64>,
 ) -> Result<(), Error> {
@@ -71,8 +88,9 @@ pub fn verify_sweep_auth(
     // Get the sweep controller contract address
     let contract_id = env.current_contract_address();
 
-    // Construct the message that should have been signed
-    let message = construct_sweep_message(env, destination, &contract_id);
+    // Construct the message that should have been signed. The account is
+    // included so the signature cannot be replayed on a different account.
+    let message = construct_sweep_message(env, account, destination, &contract_id);
 
     // Verify the Ed25519 signature
     env.crypto()

--- a/contracts/sweep_controller/src/storage.rs
+++ b/contracts/sweep_controller/src/storage.rs
@@ -1,3 +1,16 @@
+//! Contract storage for the SweepController.
+//!
+//! Issue #25 — storage key collision audit:
+//! Every storage key is a distinct variant of the [`DataKey`] enum and is
+//! written to the contract's own `instance()` storage. Soroban isolates
+//! storage per contract instance — one deployed instance can never read or
+//! write another instance's entries — so an explicit contract-address prefix
+//! is unnecessary to prevent cross-instance collisions. Within a single
+//! instance the variants below are mutually exclusive, so no intra-instance
+//! collision is possible either. When adding a key, add a new `DataKey`
+//! variant rather than reusing an existing one or introducing raw
+//! string/symbol keys.
+
 use soroban_sdk::{contracttype, Address, BytesN, Env};
 
 /// Data keys for contract storage

--- a/docs/SIGNATURE_FORMAT.md
+++ b/docs/SIGNATURE_FORMAT.md
@@ -8,10 +8,18 @@ The sweep controller uses **Ed25519 signature verification** to ensure only auth
 
 ## Message Construction
 
+> **Update (Issue #29):** the signed message now includes the **ephemeral
+> account address** as its first component. This binds a signature to the
+> specific account it authorizes, so a captured signature can no longer be
+> replayed against a different ephemeral account served by the same controller.
+> Signatures produced against the previous three-component format will no
+> longer verify — off-chain signers must prepend the account XDR bytes.
+
 The message to be signed is constructed as follows:
 
 ```
 message = SHA256(
+    account_address_xdr     ||
     destination_address_xdr ||
     sweep_nonce_be_u64      ||
     contract_id_xdr
@@ -20,24 +28,29 @@ message = SHA256(
 
 ### Components
 
-1. **destination_address_xdr** (variable length)
+1. **account_address_xdr** (variable length)
+   - The ephemeral account the sweep authorizes funds to leave
+   - Serialized as XDR bytes using `soroban_sdk::Address::to_xdr(&env)`, the same way as the destination
+   - Binds the signature to a specific account — a signature valid for one ephemeral account will not verify for another
+
+2. **destination_address_xdr** (variable length)
    - The wallet address where funds will be swept to
    - Serialized as XDR bytes using `soroban_sdk::Address::to_xdr(&env)` — the Soroban SDK's own serialization, not a hand-rolled encoding of the `G...`/`C...` strkey
    - Length varies by address type; don't assume a fixed size
 
-2. **sweep_nonce** (8 bytes, big-endian)
+3. **sweep_nonce** (8 bytes, big-endian)
    - Unsigned 64-bit integer
    - Starts at 0 for the first sweep (set at `initialize()`)
    - Increments by 1 after each successful sweep authorization
    - Prevents replay attacks by invalidating previous signatures
    - **The contract always verifies against its own current on-chain nonce.** Query it with `SweepController::get_nonce()` before signing — don't rely on a locally-tracked counter, which can drift if a sweep fails partway or another process triggers one.
 
-3. **contract_id** (variable length)
+4. **contract_id** (variable length)
    - The address of the sweep controller contract itself (`env.current_contract_address()`)
    - Serialized as XDR bytes the same way as the destination
    - Binds the signature to a specific contract deployment — a signature valid on one `SweepController` instance will not verify on another
 
-There is no timestamp, expiry, or any fourth component. The concatenated bytes above are hashed exactly once with SHA-256, and that 32-byte digest is what gets Ed25519-signed.
+There is no timestamp or expiry component. The concatenated bytes above are hashed exactly once with SHA-256, and that 32-byte digest is what gets Ed25519-signed.
 
 ### Hash Function
 
@@ -71,6 +84,7 @@ import * as crypto from 'crypto';
 import * as ed25519 from '@noble/ed25519';
 
 interface SweepAuthParams {
+  accountXdr: Buffer;       // ephemeral account Address::to_xdr() bytes — see note above
   destinationXdr: Buffer;   // Address::to_xdr() bytes — see note above
   contractIdXdr: Buffer;    // Address::to_xdr() bytes — see note above
   nonce: bigint;            // current on-chain nonce; query get_nonce() first
@@ -86,6 +100,7 @@ async function generateSweepSignature(
 
   // Concatenate all components — destination, nonce, contract_id, in that order
   const message = Buffer.concat([
+    params.accountXdr,
     params.destinationXdr,
     nonceBuffer,
     params.contractIdXdr,
@@ -110,6 +125,7 @@ async function verifySweepSignature(
   nonceBuffer.writeBigUInt64BE(params.nonce, 0);
 
   const message = Buffer.concat([
+    params.accountXdr,
     params.destinationXdr,
     nonceBuffer,
     params.contractIdXdr,
@@ -125,6 +141,7 @@ const privateKeyHex = 'your-private-key-hex';
 const privateKey = Buffer.from(privateKeyHex, 'hex');
 
 const params: SweepAuthParams = {
+  accountXdr: Buffer.from('...', 'base64'),     // properly XDR-encoded, see note above
   destinationXdr: Buffer.from('...', 'base64'), // properly XDR-encoded, see note above
   contractIdXdr: Buffer.from('...', 'base64'),  // properly XDR-encoded, see note above
   nonce: 0n,
@@ -150,6 +167,7 @@ class SweepAuthSigner:
 
     def construct_message(
         self,
+        account_xdr: bytes,
         destination_xdr: bytes,
         contract_id_xdr: bytes,
         nonce: int,
@@ -157,19 +175,20 @@ class SweepAuthSigner:
         """Construct the message to be signed."""
         nonce_bytes = struct.pack('>Q', nonce)  # Big-endian unsigned 64-bit
 
-        # Concatenate: destination, nonce, contract_id — no timestamp
-        message = destination_xdr + nonce_bytes + contract_id_xdr
+        # Concatenate: account, destination, nonce, contract_id — no timestamp
+        message = account_xdr + destination_xdr + nonce_bytes + contract_id_xdr
 
         return message
 
     def generate_signature(
         self,
+        account_xdr: bytes,
         destination_xdr: bytes,
         contract_id_xdr: bytes,
         nonce: int,
     ) -> bytes:
         """Generate Ed25519 signature for sweep authorization."""
-        message = self.construct_message(destination_xdr, contract_id_xdr, nonce)
+        message = self.construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce)
 
         # Hash the message with SHA-256
         message_hash = hashlib.sha256(message).digest()
@@ -181,13 +200,14 @@ class SweepAuthSigner:
 
     def verify_signature(
         self,
+        account_xdr: bytes,
         destination_xdr: bytes,
         contract_id_xdr: bytes,
         nonce: int,
         signature: bytes,
     ) -> bool:
         """Verify sweep authorization signature."""
-        message = self.construct_message(destination_xdr, contract_id_xdr, nonce)
+        message = self.construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce)
         message_hash = hashlib.sha256(message).digest()
 
         try:
@@ -201,15 +221,16 @@ class SweepAuthSigner:
 private_key_hex = 'your-private-key-hex'
 signer = SweepAuthSigner(private_key_hex)
 
+account_xdr = b'...'  # XDR-encoded ephemeral account address, see note above
 destination_xdr = b'...'  # XDR-encoded destination address, see note above
 contract_id_xdr = b'...'  # XDR-encoded contract ID, see note above
 nonce = 0  # query SweepController.get_nonce() first — don't hardcode in real use
 
-signature = signer.generate_signature(destination_xdr, contract_id_xdr, nonce)
+signature = signer.generate_signature(account_xdr, destination_xdr, contract_id_xdr, nonce)
 print('Signature (hex):', signature.hex())
 
 # Verify
-is_valid = signer.verify_signature(destination_xdr, contract_id_xdr, nonce, signature)
+is_valid = signer.verify_signature(account_xdr, destination_xdr, contract_id_xdr, nonce, signature)
 print(f'Signature valid: {is_valid}')
 ```
 
@@ -230,11 +251,13 @@ impl SweepAuthSigner {
     }
 
     pub fn construct_message(
+        account_xdr: &[u8],
         destination_xdr: &[u8],
         contract_id_xdr: &[u8],
         nonce: u64,
     ) -> Vec<u8> {
         let mut message = Vec::new();
+        message.extend_from_slice(account_xdr);
         message.extend_from_slice(destination_xdr);
         message.extend_from_slice(&nonce.to_be_bytes());
         message.extend_from_slice(contract_id_xdr);
@@ -243,11 +266,12 @@ impl SweepAuthSigner {
 
     pub fn generate_signature(
         &self,
+        account_xdr: &[u8],
         destination_xdr: &[u8],
         contract_id_xdr: &[u8],
         nonce: u64,
     ) -> Vec<u8> {
-        let message = Self::construct_message(destination_xdr, contract_id_xdr, nonce);
+        let message = Self::construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce);
 
         let mut hasher = Sha256::new();
         hasher.update(&message);
@@ -259,12 +283,13 @@ impl SweepAuthSigner {
 
     pub fn verify_signature(
         &self,
+        account_xdr: &[u8],
         destination_xdr: &[u8],
         contract_id_xdr: &[u8],
         nonce: u64,
         signature_bytes: &[u8; 64],
     ) -> bool {
-        let message = Self::construct_message(destination_xdr, contract_id_xdr, nonce);
+        let message = Self::construct_message(account_xdr, destination_xdr, contract_id_xdr, nonce);
 
         let mut hasher = Sha256::new();
         hasher.update(&message);
@@ -279,11 +304,12 @@ impl SweepAuthSigner {
 let private_key_bytes = [0u8; 32]; // Load from secure storage
 let signer = SweepAuthSigner::new(&private_key_bytes);
 
+let account_xdr = b"..."; // XDR-encoded ephemeral account, see note above
 let destination_xdr = b"..."; // XDR-encoded destination, see note above
 let contract_id_xdr = b"..."; // XDR-encoded contract ID, see note above
 let nonce = 0u64; // query get_nonce() first — don't hardcode in real use
 
-let signature = signer.generate_signature(destination_xdr, contract_id_xdr, nonce);
+let signature = signer.generate_signature(account_xdr, destination_xdr, contract_id_xdr, nonce);
 println!("Signature: {}", hex::encode(&signature));
 ```
 
@@ -304,7 +330,7 @@ The off-chain system should:
 2. **Query current contract state** to get:
    - Current nonce, via `SweepController::get_nonce()`
    - Contract ID (the deployed `SweepController` address)
-3. **Construct message** using the format above (destination, nonce, contract_id — no timestamp)
+3. **Construct message** using the format above (account, destination, nonce, contract_id — no timestamp)
 4. **Sign message** with the authorized signer's private key
 5. **Call `execute_sweep` contract function** with the generated signature
 
@@ -319,6 +345,7 @@ The off-chain system should:
 
 ### Signature Validity
 
+- Signatures are **bound to a specific ephemeral account** via account_address — a signature authorizing one account cannot be replayed against another account served by the same controller
 - Signatures are **bound to a specific contract deployment** via contract_id
 - Signatures cannot be used against a different deployment
 - Signatures do **not** expire based on time — there is no timestamp or expiry window in this scheme. The only thing that invalidates a previously-issued, not-yet-used signature is the nonce advancing (i.e. another sweep happening first). If you need time-bounded authorization, that would have to be built as a new feature — it does not exist today.
@@ -337,7 +364,7 @@ The off-chain system should:
 
 ### "SignatureVerificationFailed" Error
 - The signature does not match the expected message
-- Verify that all message components are constructed correctly, in order: destination XDR, then 8-byte big-endian nonce, then contract ID XDR — no timestamp
+- Verify that all message components are constructed correctly, in order: account XDR, then destination XDR, then 8-byte big-endian nonce, then contract ID XDR — no timestamp
 - Ensure the correct public key is being used for verification
 - Check that the nonce used matches the contract's current `get_nonce()` value at the moment of signing — it may have advanced since you last checked
 

--- a/docs/soroban-sdk-version-policy.md
+++ b/docs/soroban-sdk-version-policy.md
@@ -1,0 +1,53 @@
+# soroban-sdk Version Policy (Issue #42)
+
+## Single pinned version
+
+`soroban-sdk` is pinned in exactly one place — the root `Cargo.toml`
+`[workspace.dependencies]` table:
+
+```toml
+[workspace.dependencies]
+soroban-sdk = "22.0.0"
+```
+
+Every workspace member (`ephemeral_account`, `sweep_controller`, `shared`,
+`reserve_contract`, `account_factory`) consumes it by inheritance, so no
+individual crate declares its own version:
+
+```toml
+# in each contract Cargo.toml
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+```
+
+This guarantees all contracts, the shared crate, and the test/`testutils`
+builds compile against **one identical** SDK version. Changing the version in
+the workspace table changes it everywhere at once.
+
+## Upgrade process
+
+Do **not** bump the pin casually. Follow these steps for any SDK upgrade:
+
+1. Open a dedicated branch for the upgrade — never bundle it with feature work.
+2. Update `soroban-sdk` in the root `Cargo.toml` `[workspace.dependencies]`
+   only. Run `cargo update -p soroban-sdk` to refresh `Cargo.lock`.
+3. Build every contract: `stellar contract build`.
+4. Run the full suite: `cargo test` in every contract, including the
+   `sweep_controller` integration tests.
+5. Run `cargo fmt -- --check` and `cargo clippy -- -D warnings` per contract.
+6. **Deploy the built WASM to testnet and exercise the full lifecycle**
+   (initialize → record payment → sweep/claim → expire/recover) before the
+   change is allowed to reach `main`. A green local build is not sufficient
+   evidence for an SDK bump.
+7. Note the SDK version and testnet contract IDs used for verification in the
+   PR description so the upgrade is auditable.
+
+## Rationale
+
+The SDK defines the host ABI, serialization, and auth semantics the contracts
+rely on. A silent minor bump can change generated WASM and on-chain behaviour,
+so the version is centralised and every bump is gated on an explicit testnet
+verification step.


### PR DESCRIPTION
## Summary

Addresses four issues in one branch.

### #40 — Define all contract events in shared/events.rs
Moves the event struct schemas (`AccountCreated`, `PaymentReceived`, `SweepExecutedMulti`, `MultiPaymentReceived`, `AccountExpired`, `ReserveReclaimed`) out of `ephemeral_account/src/events.rs` into the shared crate (`contracts/shared/src/events.rs`) and re-exports them from `bridgelet-shared`. The ephemeral contract keeps its thin `emit_*` helpers and re-exports the types, so its public API is unchanged and the SDK/both contracts share one identical schema.

### #29 — Add replay protection to sweep authorization
The signed sweep message previously covered `destination + nonce + contract_id` but left the ephemeral `account` parameter unused, so a captured signature could be replayed against a different account served by the same controller. This binds the **account address** into the signed message (`hash(account + destination + nonce + contract_id)`), so a signature is now tied to the specific account it authorizes. `docs/SIGNATURE_FORMAT.md` is updated to match (format, components, and all language examples).

### #25 — Audit SweepController storage.rs for key collisions
Documents the audit finding as a module doc: every key is a distinct `DataKey` enum variant written to the contract's own `instance()` storage, and Soroban isolates storage per contract instance — so cross-instance collisions are impossible and an address prefix is unnecessary. Adds guidance to keep using enum variants (no raw string/symbol keys) going forward.

### #42 — Pin soroban-sdk to 22.0.0 across all Cargo.toml files
The pin is already centralised in the root `[workspace.dependencies]` (`soroban-sdk = "22.0.0"`), with every member inheriting it via `{ workspace = true }` — so no per-crate version drift exists. This PR completes the outstanding acceptance criterion by **documenting the version policy and the testnet-gated upgrade process** (`docs/soroban-sdk-version-policy.md`) and clarifying the intent in the root `Cargo.toml`.

### Notes
- The event move preserves every public re-export path (`ephemeral_account::ReserveReclaimed`, etc.), so existing tests and the `contractimport!` interface are unaffected.
- The replay-protection change alters the signed-message format; existing integration tests exercise `execute_sweep` only with invalid signatures (expecting rejection), so they remain valid.

Closes #141
Closes #157
Closes #153
Closes #143