### PR TITLE
feat(sweep_controller): emit SweepExecutedMulti with per-asset paymen…

### DIFF
--- a/contracts/sweep_controller/src/lib.rs
+++ b/contracts/sweep_controller/src/lib.rs
@@ -116,6 +116,19 @@ impl SweepController {
         let amount: i128 = info.payments.iter().map(|p| p.amount).sum();
 
         Self::authorize_claim(&env, &ephemeral_account, &recipient)?;
+
+        // Same conversion note as sweep_account(): info.payments is the
+        // contractimport!-generated Payment type, not bridgelet_shared::Payment.
+        let mut payments_vec = Vec::new(&env);
+        for payment in info.payments.iter() {
+            payments_vec.push_back(Payment {
+                asset: payment.asset.clone(),
+                amount: payment.amount,
+                timestamp: payment.timestamp,
+            });
+        }
+
+        emit_sweep_executed_multi(&env, recipient.clone(), payments_vec);
         emit_sweep_completed(&env, ephemeral_account, recipient, amount);
 
         Ok(())
@@ -209,7 +222,8 @@ impl SweepController {
         transfers::execute_transfers(env, &ephemeral_account, &destination, &payments_vec)
             .map_err(|_| Error::TransferFailed)?;
 
-        // Emit sweep completed event after successful transfer.
+        // Emit the per-asset breakdown, then the summed completion event.
+        emit_sweep_executed_multi(env, destination.clone(), payments_vec);
         emit_sweep_completed(env, ephemeral_account, destination, amount);
 
         Ok(())
@@ -341,6 +355,15 @@ pub struct SweepCompleted {
     pub amount: i128,
 }
 
+/// Multi-asset sweep event: full per-asset payment breakdown for a sweep,
+/// emitted alongside the summed SweepCompleted event.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SweepExecutedMulti {
+    pub destination: Address,
+    pub payments: Vec<Payment>,
+}
+
 /// Destination authorized event (emitted when destination is set during initialization)
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -364,6 +387,15 @@ fn emit_sweep_completed(env: &Env, account: Address, destination: Address, amoun
     };
     env.events()
         .publish((soroban_sdk::symbol_short!("sweep"),), event);
+}
+
+fn emit_sweep_executed_multi(env: &Env, destination: Address, payments: Vec<Payment>) {
+    let event = SweepExecutedMulti {
+        destination,
+        payments,
+    };
+    env.events()
+        .publish((soroban_sdk::symbol_short!("swp_multi"),), event);
 }
 
 fn emit_destination_authorized(env: &Env, destination: Address) {

--- a/contracts/sweep_controller/tests/integration.rs
+++ b/contracts/sweep_controller/tests/integration.rs
@@ -1176,3 +1176,107 @@ fn test_claim_with_flexible_destination() {
     assert_eq!(ephemeral_client.get_status(), AccountStatus::Swept);
     assert_eq!(ephemeral_client.get_info().swept_to, Some(any_recipient));
 }
+
+/// SweepExecutedMulti event is emitted with every asset's payment on a
+/// multi-asset claim, not just the summed SweepCompleted event.
+#[test]
+fn test_claim_emits_sweep_executed_multi_with_all_assets() {
+    let env = Env::default();
+
+    let (controller_client, controller_id, ephemeral_client, ephemeral_id) = deploy_contracts(&env);
+
+    let controller_creator = Address::generate(&env);
+    let (authorized_signer, _) = generate_test_keypair(&env);
+    let recipient = Address::generate(&env);
+
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &controller_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_id,
+                fn_name: "initialize",
+                args: (
+                    &controller_creator,
+                    &authorized_signer,
+                    &Some(recipient.clone()),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(
+            &controller_creator,
+            &authorized_signer,
+            &Some(recipient.clone()),
+        );
+
+    let account_creator = Address::generate(&env);
+    let recovery = Address::generate(&env);
+    let expiry = env.ledger().sequence() + 1_000;
+
+    ephemeral_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &account_creator,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &ephemeral_id,
+                fn_name: "initialize",
+                args: (
+                    &account_creator,
+                    &expiry,
+                    &recovery,
+                    &controller_id,
+                    &account_creator,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(
+            &account_creator,
+            &expiry,
+            &recovery,
+            &controller_id,
+            &account_creator,
+        );
+
+    let asset1 = Address::generate(&env);
+    let asset2 = Address::generate(&env);
+    env.mock_all_auths_allowing_non_root_auth();
+    ephemeral_client.record_payment(&100, &asset1);
+    ephemeral_client.record_payment(&250, &asset2);
+    env.set_auths(&[]);
+
+    controller_client
+        .mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &recipient,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &controller_client.address,
+                fn_name: "claim",
+                args: (&recipient, &ephemeral_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .claim(&recipient, &ephemeral_id);
+
+    let events = env.events().all();
+    let mut found_multi_event = false;
+    for i in 0..events.len() {
+        let (_contract, topics, data) = events.get_unchecked(i);
+        if let Ok(sym) = Symbol::try_from_val(&env, &topics.get(0).unwrap()) {
+            if sym == soroban_sdk::symbol_short!("swp_multi") {
+                let decoded: sweep_controller::SweepExecutedMulti =
+                    sweep_controller::SweepExecutedMulti::try_from_val(&env, &data).unwrap();
+                assert_eq!(decoded.destination, recipient);
+                assert_eq!(decoded.payments.len(), 2);
+                let total: i128 = decoded.payments.iter().map(|p| p.amount).sum();
+                assert_eq!(total, 350);
+                found_multi_event = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        found_multi_event,
+        "SweepExecutedMulti event should be emitted with all payments"
+    );
+}


### PR DESCRIPTION

Multi-asset token transfer already worked — \`execute_transfers\` loops
over every recorded payment. The gap was the documented
\`SweepExecutedMulti\` event: it existed only in interface docs, never
defined or emitted on either sweep path.

- Added \`SweepExecutedMulti { destination, payments }\` event type
- Emitted from \`execute_sweep()\` (via \`sweep_account()\`) and \`claim()\`
- New test: \`test_claim_emits_sweep_executed_multi_with_all_assets\`
- All 24 integration tests + unit tests passing (run twice, consistent)
- Note: issue referenced a nonexistent #21; no related issue/PR found
- Note: \`cargo clippy -D warnings\` surfaces 8 pre-existing lint errors
  (needless_borrow, get_first) in tests/integration.rs unrelated to this
  change — not touched here, flagging separately rather than folding an
  unrelated cleanup into this PR" \

Closes #149