### PR TITLE
Implemented the accountinit request

### DIFF
--- a/contracts/ephemeral_account/src/request.rs
+++ b/contracts/ephemeral_account/src/request.rs
@@ -1,0 +1,239 @@
+use crate::events::ReserveReclaimed;
+use bridgelet_shared::{AccountStatus, Payment};
+use soroban_sdk::{contracttype, Address, Env, Map};
+
+#[contracttype]
+pub enum Request {
+    Initialized,
+    Creator,
+    ExpiryLedger,
+    RecoveryAddress,
+    Payments,
+    Status,
+    SweptTo,
+    BaseReserveRemaining,
+    AvailableReserve,
+    ReserveReclaimed,
+    LastSweepId,
+    ReserveEventCount,
+    LastReserveEvent,
+    AuthorizedController,
+    Admin,
+}
+
+// Initialization
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Initialized)
+}
+
+pub fn set_initialized(env: &Env, value: bool) {
+    env.storage().instance().set(&DataKey::Initialized, &value);
+}
+
+// Creator
+pub fn set_creator(env: &Env, creator: &Address) {
+    env.storage().instance().set(&DataKey::Creator, creator);
+}
+
+pub fn get_creator(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Creator).unwrap()
+}
+
+// Expiry
+pub fn set_expiry_ledger(env: &Env, ledger: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ExpiryLedger, &ledger);
+}
+
+pub fn get_expiry_ledger(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ExpiryLedger)
+        .unwrap()
+}
+
+// Recovery address
+pub fn set_recovery_address(env: &Env, address: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::RecoveryAddress, address);
+}
+
+pub fn get_recovery_address(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&DataKey::RecoveryAddress)
+        .unwrap()
+}
+
+// Payments
+pub fn has_payments(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Payments)
+}
+
+pub fn get_all_payments(env: &Env) -> Map<Address, Payment> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Payments)
+        .unwrap_or_else(|| Map::new(env))
+}
+
+pub fn set_all_payments(env: &Env, payments: &Map<Address, Payment>) {
+    env.storage().instance().set(&DataKey::Payments, payments);
+}
+
+pub fn add_payment(env: &Env, payment: Payment) {
+    let mut payments = get_all_payments(env);
+    payments.set(payment.asset.clone(), payment);
+    set_all_payments(env, &payments);
+}
+
+pub fn get_payment(env: &Env, asset: &Address) -> Option<Payment> {
+    let payments = get_all_payments(env);
+    payments.get(asset.clone())
+}
+
+pub fn get_total_payments(env: &Env) -> u32 {
+    get_all_payments(env).len()
+}
+
+pub fn has_payment_received(env: &Env) -> bool {
+    has_payments(env)
+}
+
+// Status
+pub fn set_status(env: &Env, status: AccountStatus) {
+    env.storage().instance().set(&DataKey::Status, &status);
+}
+
+pub fn get_status(env: &Env) -> AccountStatus {
+    env.storage()
+        .instance()
+        .get(&DataKey::Status)
+        .unwrap_or(AccountStatus::Active)
+}
+
+// Swept to
+pub fn set_swept_to(env: &Env, address: &Address) {
+    env.storage().instance().set(&DataKey::SweptTo, address);
+}
+
+pub fn get_swept_to(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::SweptTo)
+}
+
+// Reserve lifecycle
+pub fn init_reserve_tracking(env: &Env, base_reserve: i128) {
+    set_base_reserve_remaining(env, base_reserve);
+    set_available_reserve(env, base_reserve);
+    set_reserve_reclaimed(env, base_reserve == 0);
+    set_last_sweep_id(env, 0);
+    set_reserve_event_count(env, 0);
+}
+
+pub fn set_base_reserve_remaining(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::BaseReserveRemaining, &amount);
+}
+
+pub fn get_base_reserve_remaining(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::BaseReserveRemaining)
+        .unwrap_or(0)
+}
+
+pub fn set_available_reserve(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::AvailableReserve, &amount);
+}
+
+pub fn get_available_reserve(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::AvailableReserve)
+        .unwrap_or(0)
+}
+
+pub fn set_reserve_reclaimed(env: &Env, reclaimed: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReserveReclaimed, &reclaimed);
+}
+
+pub fn is_reserve_reclaimed(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReserveReclaimed)
+        .unwrap_or(false)
+}
+
+pub fn set_last_sweep_id(env: &Env, sweep_id: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LastSweepId, &sweep_id);
+}
+
+pub fn get_last_sweep_id(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::LastSweepId)
+        .unwrap_or(0)
+}
+
+pub fn set_reserve_event_count(env: &Env, count: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReserveEventCount, &count);
+}
+
+pub fn get_reserve_event_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReserveEventCount)
+        .unwrap_or(0)
+}
+
+pub fn set_last_reserve_event(env: &Env, event: &ReserveReclaimed) {
+    env.storage()
+        .instance()
+        .set(&DataKey::LastReserveEvent, event);
+}
+
+pub fn get_last_reserve_event(env: &Env) -> Option<ReserveReclaimed> {
+    env.storage().instance().get(&DataKey::LastReserveEvent)
+}
+
+// Authorized controller
+pub fn set_authorized_controller(env: &Env, controller: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::AuthorizedController, controller);
+}
+
+pub fn get_authorized_controller(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::AuthorizedController)
+}
+
+// Admin (upgrade authority)
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::Admin)
+}
+
+// TTL management
+
+const INSTANCE_TTL_THRESHOLD: u32 = 100;
+const INSTANCE_TTL_EXTEND_TO: u32 = 518_400;
+
+pub fn extend_instance_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+}


### PR DESCRIPTION
AccountInitRequest has no room for per-account authorized_controller/admin, forcing the hardcoding bug in 
Location: contracts/shared/src/types.rs:37-41

Root cause / scenario:
AccountInitRequest { expiry_ledger: u32, recovery_address: Address } — this is the shared data contract between account_factory and its callers. There is structurally no way to request a different authorized_controller or admin per account through this type.

Impact:
This is the root cause of the critical hardcoded-controller bug found in account_factory::batch_initialize; fixing that function alone isn't possible without first extending this shared struct, since the fields simply don't exist yet.
closes #249
closes #252