### PR TITLE
docs: add glossary entries for symbol_short and auth_entry

### DIFF
--- a/bridgelet-audit/glossary/auth-entry.md
+++ b/bridgelet-audit/glossary/auth-entry.md
@@ -1,0 +1,12 @@
+# Glossary: Soroban Auth Entry
+**Path:** `bridgelet-audit/glossary/auth-entry.md`
+
+## Definition
+A `Soroban Auth Entry` is the fundamental mechanism the Soroban network uses to cryptographically verify that an invoker (User, Contract, or Ed25519 keypair) has authorized a specific contract function call with specific arguments.
+
+## `authorize_as_current_contract`
+In cross-contract calls, a contract often needs to act on its own behalf (e.g., transferring tokens it owns). The method `env.auth().authorize_as_current_contract(args)` allows the current executing contract to explicitly insert an authorization entry into the authorization tree for a downstream call.
+
+## Implications for Bridgelet Core
+- When the `SweepController` needs to pull tokens from a user's wallet, it relies on the user providing their own auth entry (either via native wallet signing or cross-contract `require_auth()`).
+- When the `AccountFactory` deploys or sweeps an ephemeral account, the factory itself might need to `authorize_as_current_contract()` to prove to the token contract that it is the legitimate owner of the funds being transferred out of the factory's pool.

--- a/bridgelet-audit/glossary/symbol-short-limit.md
+++ b/bridgelet-audit/glossary/symbol-short-limit.md
@@ -1,0 +1,12 @@
+# Glossary: `symbol_short!` 9-Character Limit
+**Path:** `bridgelet-audit/glossary/symbol-short-limit.md`
+
+## Definition
+In Soroban smart contracts (Rust), the `symbol_short!` macro is used to create short `Symbol` values at compile time. However, it enforces a strict **9-character limit** for the string being converted into a symbol.
+
+## Why the Limit?
+Soroban's `Symbol` type packs characters directly into a 64-bit integer (using a custom 6-bit encoding for a subset of ASCII characters). 64 bits can store up to 10 characters (60 bits) plus some type tagging bits. `symbol_short!` guarantees that the conversion can happen zero-cost at compile time without allocating memory or utilizing dynamic environments, restricted to exactly 9 characters maximum.
+
+## Implications for Bridgelet Core
+- Key names in persistent storage (e.g., `DataKey::Admin` or `symbol_short!("Nonce")`) must be kept extremely brief.
+- If a string exceeds 9 characters, developers must use `Symbol::new(&env, "longer_string")` which incurs a minor runtime cost and interacts with the host environment.


### PR DESCRIPTION
closes #262, closes #261