### PR TITLE
Feat/sweep

### DIFF
--- a/bridgelet-audit/glossary/checks-effects-interactions.md
+++ b/bridgelet-audit/glossary/checks-effects-interactions.md
@@ -1,0 +1,73 @@
+# Glossary Entry: Checks-Effects-Interactions (CEI)
+
+**Path:** `bridgelet-audit/glossary/checks-effects-interactions.md`  
+**Component:** `EphemeralAccount`  
+**Related Functions:** `EphemeralAccount::sweep()`, `EphemeralAccount::sweep_claim()`
+
+---
+
+## Overview
+
+The Checks-Effects-Interactions (CEI) pattern is a fundamental security best practice in smart contract development that prevents reentrancy attacks and other unexpected behaviors by enforcing a strict order of operations.
+
+## General CEI Pattern Definition
+
+The pattern requires all smart contract functions to execute operations in three sequential phases:
+
+1. **Checks** (Validate): First perform all input validation, authorization checks, and precondition verifications. Revert immediately if any check fails.
+2. **Effects** (Mutate state): After all checks pass, update the contract's own state before making any external calls.
+3. **Interactions** (Make external calls): Only after state is fully updated, interact with external contracts or send Ether/tokens.
+
+This ordering prevents reentrancy attacks because by the time an external call is made, all internal state changes have already been completed, preventing an attacker from re-entering the function with the old state still intact.
+
+## Application in `EphemeralAccountContract::sweep()`
+
+The `sweep()` function in `EphemeralAccountContract` correctly implements the CEI pattern. Here's how the ordering is applied:
+
+### 1. Checks Phase (All preconditions first)
+```rust
+// Check initialized
+if !storage::is_initialized(&env) {
+    return Err(Error::NotInitialized);
+}
+// Check not already swept
+if storage::get_status(&env) == AccountStatus::Swept {
+    return Err(Error::AlreadySwept);
+}
+// Check payment received
+if !storage::has_payment_received(&env) {
+    return Err(Error::NoPaymentReceived);
+}
+// Check not expired
+if Self::is_expired(env.clone()) {
+    return Err(Error::AccountExpired);
+}
+// Verify authorization signature
+Self::verify_sweep_authorization(&env, &destination, &auth_signature)?;
+```
+
+### 2. Effects Phase (State mutation before external calls)
+```rust
+// Update account state to mark as swept - this happens BEFORE any external calls
+storage::set_status(env, AccountStatus::Swept);
+storage::set_swept_to(env, &destination);
+let sweep_id = env.ledger().sequence() as u64;
+storage::set_last_sweep_id(env, sweep_id);
+```
+
+### 3. Interactions Phase (External interactions last)
+```rust
+// Emit events (internal to the contract but part of finalization)
+events::emit_sweep_executed_multi(env, destination.clone(), &payments_vec);
+// Execute reserve reclaim which may involve external calls to transfer funds
+Self::reclaim_reserve_to(env, &destination, sweep_id)?;
+```
+
+The critical security measure here is that the account's status is set to `Swept` **before** any external calls are made to transfer funds or interact with other contracts. This prevents any reentrant calls from attempting to sweep the same account twice, as the `AlreadySwept` check would fail on any subsequent invocation.
+
+### Same Pattern Applied to `sweep_claim()`
+The `sweep_claim()` entrypoint follows the exact same CEI ordering, ensuring consistent security across both sweep pathways.
+
+## Canonical Source
+For the full reentrancy risk analysis and complete reasoning behind this implementation, see:
+[docs/reentrancy-analysis.md](file:///c:/Users/hp/Desktop/wave7/bridgelet-core/docs/reentrancy-analysis.md)

--- a/bridgelet-audit/glossary/sweep-vs-sweep-claim.md
+++ b/bridgelet-audit/glossary/sweep-vs-sweep-claim.md
@@ -8,37 +8,64 @@
 
 ## Overview
 
-Bridgelet Core provides two execution pathways for sweeping funds from an `EphemeralAccount` to a recipient address:
+Bridgelet Core's `EphemeralAccountContract` provides two entrypoints for executing a sweep:
 
-1. **Off-Chain Signed Sweep (`execute_sweep` / `EphemeralAccount::sweep`)**
-2. **Gas-Free Direct Claim (`claim` / `EphemeralAccount::sweep_claim`)**
+1. **`sweep()`**: The off-chain-signed flow, invoked exclusively by `SweepController::execute_sweep()`
+2. **`sweep_claim()`**: The native-auth claim flow, invoked exclusively by `SweepController::claim()`
 
----
-
-## Direct Comparison Matrix
-
-| Feature / Property | `execute_sweep` (`sweep`) | `claim` (`sweep_claim`) |
-| :--- | :--- | :--- |
-| **Authentication Scheme** | Ed25519 signature verified in `SweepController` | Soroban native `require_auth()` signed by recipient |
-| **Relayer / Fee Payment** | Relayer submits tx with Ed25519 signature payload | Relayer submits tx; recipient signs Soroban auth entry |
-| **Mempool Parameter Locking** | `destination` locked cryptographically inside signature | Parameter passed explicitly; subject to frontrunning in flexible mode |
-| **Sweep Nonce Update** | Increments `SweepController` nonce on success | Does **not** increment `SweepController` nonce |
-| **Destination Lock Constraint** | Checks `authorized_destination` if set | Checks `authorized_destination` if set |
-| **Account State Machine** | Transitions `Active`/`PaymentReceived` $\rightarrow$ `Swept` | Transitions `Active`/`PaymentReceived` $\rightarrow$ `Swept` |
+Both entrypoints ultimately produce identical state transitions and reserve-reclaim behavior.
 
 ---
 
-## Detailed Execution Patterns
+## Precondition Check Comparison
 
-### 1. `execute_sweep` Pathway
-- Off-chain system signs `SHA256(destination || nonce || controller_id)`.
-- Invokes `SweepController::execute_sweep(ephemeral_account, destination, auth_signature)`.
-- `SweepController` verifies signature, increments sweep nonce, authorizes downstream invocation, and calls `EphemeralAccount::sweep()`.
-- `EphemeralAccount` marks state as `Swept`, reclaims reserve, and `SweepController` executes token transfers.
+The table below lists all precondition checks performed by each entrypoint before allowing a sweep to execute. Most checks are shared, but they differ in their authorization mechanisms and input requirements.
 
-### 2. `claim` Pathway
-- Recipient signs Soroban authorization entry for `SweepController::claim(recipient, ephemeral_account)`.
-- Relayer submits transaction and pays gas fees.
-- `SweepController` verifies `recipient.require_auth()` and checks `validate_destination()`.
-- `SweepController` invokes `EphemeralAccount::sweep_claim(recipient)` via invoker contract authorization context.
-- `EphemeralAccount` marks state as `Swept`, reclaims reserve, and `SweepController` executes token transfers.
+| Precondition Check | `EphemeralAccount::sweep()` (off-chain flow) | `EphemeralAccount::sweep_claim()` (native-auth flow) |
+| :--- | :---: | :---: |
+| Contract must be initialized | ✅ | ✅ |
+| Account status must not already be `Swept` | ✅ | ✅ |
+| Account must have received at least one payment (`has_payment_received()`) | ✅ | ✅ |
+| Account must not be expired (`!is_expired()`) | ✅ | ✅ |
+| Caller must be the `authorized_controller` | ✅ | ✅ |
+| Ed25519 signature verification (of `auth_signature`) | ✅ | ❌ (not required) |
+| Requires `auth_signature` input parameter | ✅ | ❌ |
+
+### Key Differences in Preconditions
+- **Authorization method**: The `sweep()` entrypoint verifies an Ed25519 signature passed as `auth_signature`, while `sweep_claim()` relies on Soroban's native `require_auth()` enforced by the `SweepController`
+- **Input requirements**: `sweep()` requires an additional `auth_signature` parameter that `sweep_claim()` does not need
+- **Controller verification**: Both ensure the caller is the authorized controller, but `sweep_claim()` enforces this via `controller.require_auth()` immediately upon entry
+
+---
+
+## Intended Callers & Execution Flows
+
+### 1. Off-Chain-Signed Flow (`sweep()` invoked by `SweepController::execute_sweep()`)
+**Intended caller**: Only `SweepController::execute_sweep()` — this entrypoint should never be called directly.
+- The off-chain Bridgelet signer produces an Ed25519 signature over `hash(destination || nonce || controller_id)`
+- A relayer submits a transaction invoking `SweepController::execute_sweep(ephemeral_account, destination, auth_signature)`
+- `SweepController` verifies the Ed25519 signature, increments its internal sweep nonce, and authorizes the cross-contract call
+- `SweepController` calls `EphemeralAccount::sweep()`, which performs its own precondition checks including re-verifying the signature
+- The account transitions to `Swept`, reserve is reclaimed, and tokens are transferred to the destination
+
+### 2. Native-Auth Claim Flow (`sweep_claim()` invoked by `SweepController::claim()`)
+**Intended caller**: Only `SweepController::claim()` — this entrypoint should never be called directly.
+- The recipient signs a Soroban native authorization entry for `SweepController::claim(recipient, ephemeral_account)`
+- A relayer submits the transaction and pays all gas fees
+- `SweepController` first verifies `recipient.require_auth()` to confirm the recipient has authorized the claim
+- `SweepController` validates the destination against any `authorized_destination` restrictions
+- `SweepController` calls `EphemeralAccount::sweep_claim(recipient)`, which verifies the caller is the authorized controller
+- The account transitions to `Swept`, reserve is reclaimed, and tokens are transferred to the recipient
+
+---
+
+## Shared Outcome (Identical State & Reserve Behavior)
+
+Despite their different authorization flows and precondition check ordering, both entrypoints ultimately execute identical final logic:
+1. Set account status to `AccountStatus::Swept`
+2. Record the destination address the account was swept to
+3. Generate a sweep ID from the current ledger sequence
+4. Emit the `SweepExecutedMulti` event with all payments
+5. Reclaim the account's reserve balance to the destination via `reclaim_reserve_to()`
+
+Both flows result in the same final state for the ephemeral account and identical reserve-reclaim semantics.


### PR DESCRIPTION
## Summary of Changes:

1. **Tabulated precondition checks**: Created a clear comparison table showing all precondition checks performed by both entrypoints, highlighting the key differences
2. **Explained intended callers**: Clearly stated that each entrypoint is exclusively invoked by its corresponding SweepController method (`execute_sweep()` for `sweep()`, `claim()` for `sweep_claim()`)
3. **Documented execution flows**: Provided detailed step-by-step flows for both the off-chain-signed flow and the native-auth claim flow
4. **Verified shared outcomes**: Explicitly stated that both entrypoints produce identical state transitions and reserve-reclaim behavior, listing the exact shared final logic they execute

closes #265

The file now accurately documents the two sweep entrypoints in EphemeralAccountContract, fulfilling all the requirements specified in the issue. The documentation is contained entirely within the bridgelet-audit/glossary directory as requested, with no changes needed to any other parts of the codebase.

closes #259

## Summary of what was implemented:

1. **Created the new file**: `bridgelet-audit/glossary/checks-effects-interactions.md` - a standalone documentation file as requested
2. **Described the CEI pattern**: Explained the three phases (Checks, Effects, Interactions) and how it prevents reentrancy attacks
3. **Pointed to sweep() implementation**: Showcased the exact code from `EphemeralAccountContract::sweep()` that implements the pattern, highlighting that `state.set_status(Swept)` happens before any external interactions
4. **Cross-referenced reentrancy analysis**: Included a link to `docs/reentrancy-analysis.md` as the canonical source for full reasoning

closes #258 

6. **Covered both entrypoints**: Mentioned that `sweep_claim()` follows the same secure pattern for consistency

The file fulfills all the requirements: it's documentation-only, lives in the correct bridgelet-audit/glossary directory, and explains how the CEI pattern is applied in the sweep() function. No changes were made to contracts/, docs/, scripts/, or tools/ as requested.

closes #257 