### PR TITLE
Feat/build

### DIFF
--- a/bridgelet-audit/glossary/salt-based-deployment.md
+++ b/bridgelet-audit/glossary/salt-based-deployment.md
@@ -1,0 +1,51 @@
+# Salt-Based Deployment
+
+## What is a Salt in batch_initialize's deploy_v2 Calls?
+
+In the context of `AccountFactory::batch_initialize` and Soroban's `deploy_v2`, a **salt** is a 32-byte value used as input to deterministic contract address derivation. When deploying contracts via Soroban's deployer API, the resulting contract address is computed as:
+```
+contract_address = H(factory_address, salt, wasm_hash, init_args)
+```
+This deterministic derivation mechanism is analogous to Ethereum's CREATE2 deployment style, which enables precomputation of contract addresses before they are deployed.
+
+## Salt Derivation in the Current Implementation
+
+The current implementation in the AccountFactory contract derives a unique salt for each request in a batch by combining two values:
+1. **A monotonic factory-wide batch nonce**: A `u64` counter stored in the factory's instance storage that increments by exactly 1 for every invocation of `batch_initialize`
+2. **The request's position (index) in the batch**: A `u32` representing the 0-based index of the request within the current batch's requests vector
+
+### Salt Layout (32 bytes, big-endian):
+```
+[0..8]   nonce   — monotonically increases each call to batch_initialize
+[8..28]  zeros   — reserved for future use
+[28..32] index   — per-request position inside the current batch
+```
+
+The code that constructs this salt (from [multiple.rs](file:///c:/Users/n-ishaq/Desktop/wave7/bridgelet-core/contracts/account_factory/src/multiple.rs#L131-L134)):
+```rust
+let mut salt_bytes = [0u8; 32];
+salt_bytes[0..8].copy_from_slice(&nonce.to_be_bytes());
+salt_bytes[28..32].copy_from_slice(&(index as u32).to_be_bytes());
+let salt = BytesN::from_array(&env, &salt_bytes);
+```
+
+## Required Uniqueness Properties
+
+For the deployment system to work safely across the contract's entire lifetime, salts must satisfy these critical uniqueness properties:
+
+1. **Global uniqueness across all deployments**: No two ephemeral account deployments from the same factory can ever use the same salt. This guarantees no address collisions, which would cause `deploy_v2` to fail or interact with an existing contract incorrectly.
+
+2. **Batch isolation**: Separate invocations of `batch_initialize` must produce completely disjoint sets of addresses, even if they contain the same number of requests at the same indices. The monotonic batch nonce ensures this — since the nonce always increases, the first 8 bytes of the salt will never repeat across different batch calls.
+
+3. **Within-batch uniqueness**: Within a single batch call, every request must have a unique index. Since the loop iterates with `enumerate()`, each index is guaranteed to be unique within the batch, ensuring the last 4 bytes of the salt are distinct.
+
+4. **Overflow prevention**: The batch nonce is a `u64`, which can never realistically overflow (it would require 1.8e19 batch calls to exhaust the space). The workspace enables `overflow-checks = true` in release builds, so any hypothetical overflow would panic rather than silently wrap around and produce colliding salts.
+
+## Relationship to CREATE2-Style Deployment
+
+This salt-based deterministic deployment follows the same principles as **CREATE2-style deployment** (a common pattern in smart contract ecosystems for deterministic address generation). Like CREATE2, Soroban's `deploy_v2` with a salt allows:
+- Precomputing contract addresses before deployment
+- Guaranteeing address uniqueness when salts are unique
+- Avoiding reliance on transaction order or nonce-based address derivation
+
+While this repository does not currently have a standalone `create2-style-deployment.md` glossary entry, the salt mechanism used here implements the core concepts of that pattern within the Soroban runtime's specific implementation.

--- a/bridgelet-audit/glossary/wasm32v1-none-target.md
+++ b/bridgelet-audit/glossary/wasm32v1-none-target.md
@@ -1,0 +1,56 @@
+# wasm32v1-none Target
+
+## What is wasm32v1-none?
+
+`wasm32v1-none` is the **only compilation target officially supported by the Soroban runtime** for building Stellar smart contracts. It is a Soroban/Stellar-specific WebAssembly target that differs from the more generic `wasm32-unknown-unknown` target in critical ways:
+
+- **Feature compatibility**: Unlike generic WASM targets that may enable modern WASM features like reference-types or multivalue (which Soroban's runtime rejects), `wasm32v1-none` exclusively emits WASM that conforms to the exact feature set the Soroban VM supports.
+- **Soroban-native**: This target is maintained and recommended by Stellar for all Soroban contract development. Using it avoids common runtime errors like `HostError: Error(Wasmvm, InvalidAction) / "reference-types not enabled"` that can occur with newer Rust versions and generic targets.
+- **Official tooling**: The standard `stellar contract build` command (from stellar-cli) automatically uses this target, as documented in the [soroban-sdk documentation](https://docs.rs/soroban-sdk/latest/soroban_sdk/).
+
+## All References in This Repository
+
+### CI Workflow Configurations
+
+1. **`.github/workflows/test.yml`**
+   - Build step uses `cargo build --target wasm32v1-none --release` for all three core contracts
+   - Lines 77-83:
+     ```bash
+     cd contracts/ephemeral_account
+     cargo build --target wasm32v1-none --release
+     cd ../sweep_controller
+     cargo build --target wasm32v1-none --release
+     cd ../reserve_contract
+     cargo build --target wasm32v1-none --release
+     ```
+
+2. **`.github/workflows/test.yml` - Artifact Upload Paths**
+   - Uploads WASM artifacts from the wasm32v1-none build directories
+   - Lines 88-92:
+     ```yaml
+     path: |
+       contracts/ephemeral_account/target/wasm32v1-none/release/*.wasm
+       contracts/sweep_controller/target/wasm32v1-none/release/*.wasm
+       contracts/reserve_contract/target/wasm32v1-none/release/*.wasm
+     ```
+
+### Scripts
+
+1. **`scripts/build.sh`**
+   - Explicitly documents why wasm32v1-none is preferred over wasm32-unknown-unknown
+   - Notes that `stellar contract build` (which uses wasm32v1-none) is the recommended build approach
+   - Explains the historical context: previous use of wasm32-unknown-unknown caused compatibility issues with Rust 1.82+ due to unsupported WASM features
+
+### Codebase References
+
+The target string `wasm32v1-none` appears in test files and runbooks across the repository, including:
+- `test_fixtures/mock_v2/src/test_upgrade.rs`
+- `contracts/account_factory/src/multiple.rs`
+- `contracts/account_factory/src/test.rs`
+- `contracts/account_factory/tests/batch.rs`
+- `contracts/account_factory/tests/e2e_pipeline.rs`
+- Multiple runbooks in `bridgelet-audit/runbooks/` that reference WASM build paths and verification processes
+
+## Note
+
+This is purely a descriptive document. No changes to the repository's build configuration are proposed here. The wasm32v1-none target is the correct, supported target for Soroban contract development in this codebase.


### PR DESCRIPTION
1. **Explanation of the target**: It clearly describes what `wasm32v1-none` is as a Soroban-specific WASM target, and how it differs from the generic `wasm32-unknown-unknown` target, including the critical feature compatibility issue that led to its adoption.

2. **All references in the repository**: I've listed every place the target is used, including:
   - CI workflow configurations in `.github/workflows/test.yml` with exact line numbers and code snippets
   - Artifact upload paths in the same workflow file
   - Documentation in `scripts/build.sh` that explains the rationale for using this target
   - All test files and runbooks that reference the target string

closes #268

3. **Scope note**: The file includes a clear statement that this is purely descriptive and does not propose any build configuration changes, as required.

The glossary entry follows the same pattern as the existing entries in the `bridgelet-audit/glossary/` directory and meets all the requirements specified in the issue.

1. **Definition of a salt**: Explains what a salt is in the context of `batch_initialize`'s `deploy_v2` calls, and how it's used in Soroban's deterministic address derivation.

closes #266 

3. **Salt derivation explanation**: Details how the current implementation combines a monotonic factory-wide batch nonce with the request's position (index) in the batch to create unique salts, including the exact byte layout and code snippet from the implementation.

4. **Uniqueness properties**: Describes all the critical uniqueness properties salts must have across the contract's entire lifetime, including global uniqueness, batch isolation, within-batch uniqueness, and overflow prevention.

closes #264 

6. **CREATE2-style deployment reference**: Links the salt mechanism to the broader CREATE2-style deployment pattern, explaining how it implements those core concepts within Soroban's runtime, while noting that a separate `create2-style-deployment.md` entry doesn't currently exist in the repository.

The file is purely documentation as requested, follows the same pattern as existing glossary entries, and makes no changes to any code or other functional files in the repository.

closes #256 